### PR TITLE
fix: Update static_analysis workflow with folder filtering and upgrades

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -10,7 +10,25 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - name: Static Analysis
-        uses: pagopa/eng-github-actions-iac-template/azure/terraform-static-analysis@5c7e5f690ad0f07f3bd945bdebf2a6c7a575b33f # v1.20.0
+      - name: 🔨 Get Modified Paths
+        id: get-paths
+        uses: pagopa/eng-github-actions-iac-template/global/get-modifed-folders@f10814b649ecd6e5d97c489084d2a107e2f1b2ee #v1.22.3
         with:
-          precommit_version: 'v1.97.3@sha256:cab76405fc6d068e20ca7c5a6f8d17c527356eed31dbc54151aec9fac65da128'
+          ignore_patterns: ".github,.devops,.vscode,.terraform-version,90_aws"
+          start_folder: "src"
+          include_folders: "tag_config"
+          include_patterns: "src"
+          stopper_folders: "env,tests,api,api_product,api_fragment"
+
+      - name: 👀 See folders downloaded
+        if: env.dir_changes_detected == 'true'
+        id: see
+        shell: bash
+        run: |
+          tree -R -d -a .
+
+      - name: Static Analysis
+        if: env.dir_changes_detected == 'true'
+        uses: pagopa/eng-github-actions-iac-template/azure/terraform-static-analysis@159289e1e23d0783533d1dd83e1b7cf0a5a565d9 #v1.24.0
+        with:
+          precommit_version: 'v1.99.2@sha256:34f6cef8b944d571ea22be316a960d8353fcc0571adea35302cbd9ab80bf2758'


### PR DESCRIPTION
### List of changes

- Added folder filtering functionality to the `static_analysis` workflow.
- Upgraded action versions used within the `static_analysis` workflow.

### Motivation and context

This change enhances the `static_analysis` workflow by improving its efficiency through folder-specific filtering and ensuring compatibility by upgrading the action versions.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

N/A

---

### If PR is partially applied, why? (reserved to maintainer)

N/A