### PR TITLE
fix: Add status filter in rdb call

### DIFF
--- a/src/idpay/apim/api/idpay_merchants_op_portal/get-rbd-products-policy.xml.tpl
+++ b/src/idpay/apim/api/idpay_merchants_op_portal/get-rbd-products-policy.xml.tpl
@@ -14,7 +14,7 @@
     <inbound>
         <base />
         <set-backend-service base-url="https://${ingress_load_balancer_hostname}/idpayassetregisterbackend" />
-        <rewrite-uri template="@("/idpay/register/products")" />
+        <rewrite-uri template="@("/idpay/register/products?status=APPROVED")" />
     </inbound>
     <backend>
         <base />


### PR DESCRIPTION
Add status filter in rdb call](https://github.com/pagopa/cstar-securehub-infra-api-spec/commit/fe12f70a1836022cb14d28466db47fc12506e4e0)

### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
