### PR TITLE
fix: [SRTP-434] Return error body as specified

### DIFF
--- a/src/srtp/api/pagopa/service_providers_registry.yaml
+++ b/src/srtp/api/pagopa/service_providers_registry.yaml
@@ -121,6 +121,18 @@ components:
       maxLength: 64
       example: "ADMIN"
     Errors:
+      description: |
+        A generic error response container. The structure of the error can vary depending on where it originates (e.g., Application, API Gateway, or underlying Framework).
+      oneOf:
+      - $ref: '#/components/schemas/Error'
+      - $ref: '#/components/schemas/ApimError'
+
+
+
+    # --------------------------------------------------------------------------
+    # Basic types for error handling.
+    # --------------------------------------------------------------------------
+    Error:
       description: Body of an error response.
       type: object
       additionalProperties: false
@@ -136,11 +148,22 @@ components:
         - description
         - status
 
+    ApimError:
+      description: An error originating from the API Management (APIM) layer.
+      type: object
+      additionalProperties: false
+      properties:
+        statusCode:
+          $ref: '#/components/schemas/StatusCode'
+        message:
+          $ref: '#/components/schemas/ErrorDescription'
+      required:
+        - statusCode
+        - message
+      example:
+        statusCode: 401
+        message: "Invalid JWT."
 
-
-    # --------------------------------------------------------------------------
-    # Basic types for error handling.
-    # --------------------------------------------------------------------------
     ErrorCode:
       description: Error code.
       type: string


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

- Updated Errors schema to use oneOf
- Added Error (application format) and ApimError (Azure APIM format) schemas
- Updated references to use the unified error model

### Motivation and context

This change aligns the API specification, ensuring that error responses returned by the application or by Azure API Management are both valid according to the spec. This improves client compatibility and avoids validation issues.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [x] DEV
- [x] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
