### PR TITLE
feat: MMC-402 Add double issuer keycloak and mil on mdc

### DIFF
--- a/src/mdc/99_locals.tf
+++ b/src/mdc/99_locals.tf
@@ -181,8 +181,10 @@ locals {
       description = "emd-validate-token-mdc"
       format      = "rawxml"
       value = templatefile("./api_fragment/validate-token-mdc.xml", {
-        openidUrl = var.mdc_openid_url
-        issuerUrl = var.mdc_issuer_url
+        openidUrl         = var.mdc_openid_url
+        issuerUrl         = var.mdc_issuer_url
+        keycloakIssuerUrl = var.keycloak_issuer_url
+        keycloakOpenidUrl = var.keycloak_openid_url
       })
     }
   }

--- a/src/mdc/99_variables.tf
+++ b/src/mdc/99_variables.tf
@@ -66,3 +66,13 @@ variable "mdc_issuer_url" {
   type        = string
   description = "Issuer identifier for MDC token validation."
 }
+
+variable "keycloak_openid_url" {
+  type        = string
+  description = "OpenID discovery endpoint used for MDC keycloak validation."
+}
+
+variable "keycloak_issuer_url" {
+  type        = string
+  description = "Issuer identifier for Keycloak token validation."
+}

--- a/src/mdc/api_fragment/validate-token-mdc.xml
+++ b/src/mdc/api_fragment/validate-token-mdc.xml
@@ -1,11 +1,32 @@
 <!--
 This policy validate content and sign of MDC JWT token
+Supports both mil-auth and Keycloak IDPs
 -->
 <fragment>
-  <validate-jwt header-name="Authorization" failed-validation-httpcode="401" require-expiration-time="true" require-scheme="Bearer" require-signed-tokens="true" clock-skew="5" output-token-variable-name="mdcToken">
-    <openid-config url="${openidUrl}" />
-    <issuers>
-      <issuer>${issuerUrl}</issuer>
-    </issuers>
-  </validate-jwt>
+  <set-variable
+    name="iss"
+    value="@(context.Request.Headers.GetValueOrDefault("Authorization","").Split(' ').ElementAtOrDefault(1)?.AsJwt()?.Claims["iss"]?.FirstOrDefault() ?? "")" />
+
+
+  <choose>
+    <!-- Keycloak token -->
+    <when condition="@(context.Variables.GetValueOrDefault("iss", "").Equals("${keycloakIssuerUrl}"))">
+      <validate-jwt header-name="Authorization" failed-validation-httpcode="401" require-expiration-time="true" require-scheme="Bearer" require-signed-tokens="true" clock-skew="5" output-token-variable-name="mdcToken">
+        <openid-config url="${keycloakOpenidUrl}" />
+        <issuers>
+          <issuer>${keycloakIssuerUrl}</issuer>
+        </issuers>
+      </validate-jwt>
+    </when>
+
+    <!-- mil-auth token (default/fallback) -->
+    <otherwise>
+      <validate-jwt header-name="Authorization" failed-validation-httpcode="401" require-expiration-time="true" require-scheme="Bearer" require-signed-tokens="true" clock-skew="5" output-token-variable-name="mdcToken">
+        <openid-config url="${openidUrl}" />
+        <issuers>
+          <issuer>${issuerUrl}</issuer>
+        </issuers>
+      </validate-jwt>
+    </otherwise>
+  </choose>
 </fragment>

--- a/src/mdc/env/itn-dev/terraform.tfvars
+++ b/src/mdc/env/itn-dev/terraform.tfvars
@@ -10,3 +10,6 @@ rate_limit_emd_message = 60
 
 mdc_openid_url = "https://api-mcshared.dev.cstar.pagopa.it/auth/.well-known/openid-configuration"
 mdc_issuer_url = "https://api-mcshared.dev.cstar.pagopa.it/auth"
+
+keycloak_openid_url = "https://api-mcshared.dev.cstar.pagopa.it/auth-itn/realms/mdc/.well-known/openid-configuration"
+keycloak_issuer_url = "https://api-mcshared.dev.cstar.pagopa.it/auth-itn/realms/mdc"

--- a/src/mdc/env/itn-prod/terraform.tfvars
+++ b/src/mdc/env/itn-prod/terraform.tfvars
@@ -9,3 +9,6 @@ rate_limit_emd_message = 9000
 
 mdc_openid_url = "https://api-mcshared.cstar.pagopa.it/auth/.well-known/openid-configuration"
 mdc_issuer_url = "https://api-mcshared.cstar.pagopa.it/auth"
+
+keycloak_openid_url = "https://api-mcshared.cstar.pagopa.it/auth-itn/realms/mdc/.well-known/openid-configuration"
+keycloak_issuer_url = "https://api-mcshared.cstar.pagopa.it/auth-itn/realms/mdc"

--- a/src/mdc/env/itn-uat/terraform.tfvars
+++ b/src/mdc/env/itn-uat/terraform.tfvars
@@ -9,3 +9,6 @@ rate_limit_emd_message = 60
 
 mdc_openid_url = "https://api-mcshared.uat.cstar.pagopa.it/auth/.well-known/openid-configuration"
 mdc_issuer_url = "https://api-mcshared.uat.cstar.pagopa.it/auth"
+
+keycloak_openid_url = "https://api-mcshared.uat.cstar.pagopa.it/auth-itn/realms/mdc/.well-known/openid-configuration"
+keycloak_issuer_url = "https://api-mcshared.uat.cstar.pagopa.it/auth-itn/realms/mdc"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
- add issuer and openid of keycloak
- add get variable iss from token and check to with validate-jwt use for validation

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
We added keycloak but we need to still use mil-auth for the client so they can migrate from the auth of mil-auth to the one with keycloak with their time.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [x] DEV
- [x] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
