### PR TITLE
feat: [SRTP-1678] New policies for Mock

### DIFF
--- a/src/srtp/api/test/mock_policy_epc.xml
+++ b/src/srtp/api/test/mock_policy_epc.xml
@@ -168,6 +168,113 @@
           <set-body>{""InvalidResponse"</set-body>
         </return-response>
       </when>
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;BNCLCU85M15F205W&quot;))">
+        <return-response>
+          <set-status code="201" reason="Created" />
+          <set-header name="Content-Type" exists-action="override">
+            <value>application/json</value>
+          </set-header>
+          <set-body>@{
+            return @"{
+            ""resourceId"": ""TestRtpMessageA1B2C3D4E5F6G7H8"",
+            ""Document"": {
+            ""CdtrPmtActvtnReqStsRpt"": {
+            ""GrpHdr"": {
+            ""MsgId"": ""550e8400-e29b-41d4-a716-446655440000"",
+            ""CreDtTm"": ""2026-02-11T14:00:00Z"",
+            ""InitgPty"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP04"" } } }
+            },
+            ""OrgnlGrpInfAndSts"": {
+            ""OrgnlMsgId"": ""TestRtpMessageKJ9283KSL01928374650"",
+            ""OrgnlMsgNmId"": ""pain.013.001.07"",
+            ""OrgnlCreDtTm"": ""2026-02-12T09:30:00Z""
+            },
+            ""OrgnlPmtInfAndSts"": [
+            {
+            ""OrgnlPmtInfId"": ""f47ac10b-58cc-4372-a567-0e02b2c3d479"",
+            ""TxInfAndSts"": {
+            ""StsId"": ""550e8400-e29b-41d4-a716-446655440000"",
+            ""OrgnlInstrId"": ""TestRtpMessagePL098765432109876543"",
+            ""OrgnlEndToEndId"": ""123456789012345678"",
+            ""TxSts"": ""ACTC"",
+            ""StsRsnInf"": {
+            ""Orgtr"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP04"" } } }
+            },
+            ""OrgnlTxRef"": {
+            ""PmtTpInf"": {
+            ""SvcLvl"": { ""Cd"": ""SRTP"" },
+            ""LclInstrm"": { ""Prtry"": ""NOTPROVIDED"" }
+            },
+            ""RmtInf"": { ""Ustrd"": ""Payment for invoice 12345."" },
+            ""Cdtr"": {
+            ""Id"": { ""OrgId"": { ""Othr"": { ""Id"": ""TRX-ID-112233"", ""SchmeNm"": { ""Cd"": ""BOID"" } } } },
+            ""Nm"": ""Azienda Creditrice S.p.A.""
+            },
+            ""DbtrAgt"": { ""FinInstnId"": { ""BICFI"": ""MOCKSP04"" } },
+            ""CdtrAgt"": { ""FinInstnId"": { ""BICFI"": ""MOCKSP04"" } },
+            ""CdtrAcct"": { ""Id"": { ""IBAN"": ""IT12L0123456789012345678901"" } },
+            ""Amt"": { ""InstdAmt"": 450.75 },
+            ""ReqdExctnDt"": { ""Dt"": ""2026-02-20Z"" },
+            ""XpryDt"": { ""Dt"": ""2026-03-10Z"" } } } } ] } } }";
+            }</set-body>
+        </return-response>
+      </when>
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;RSSGNN92P20H501Z&quot;))">
+        <return-response>
+          <set-status code="201" reason="Created" />
+          <set-header name="Content-Type" exists-action="override">
+            <value>application/json</value>
+          </set-header>
+          <set-body>@{
+            return @"{
+            ""resourceId"": ""TestRtpMessageA1B2C3D4E5F6G7H8"",
+            ""Document"": {
+            ""CdtrPmtActvtnReqStsRpt"": {
+            ""GrpHdr"": {
+            ""MsgId"": ""550e8400-e29b-41d4-a716-446655440000"",
+            ""CreDtTm"": ""2026-02-11T14:00:00Z"",
+            ""InitgPty"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP04"" } } }
+            },
+            ""OrgnlGrpInfAndSts"": {
+            ""OrgnlMsgId"": ""TestRtpMessageKJ9283KSL01928374650"",
+            ""OrgnlMsgNmId"": ""pain.013.001.07"",
+            ""OrgnlCreDtTm"": ""2026-02-12T09:30:00Z""
+            },
+            ""OrgnlPmtInfAndSts"": [
+            {
+            ""OrgnlPmtInfId"": ""f47ac10b-58cc-4372-a567-0e02b2c3d479"",
+            ""TxInfAndSts"": {
+            ""StsId"": ""550e8400-e29b-41d4-a716-446655440000"",
+            ""OrgnlInstrId"": ""TestRtpMessagePL098765432109876543"",
+            ""OrgnlEndToEndId"": ""123456789012345678"",
+            ""TxSts"": ""ACTC"",
+            ""StsRsnInf"": {
+            ""Orgtr"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP04"" } } }
+            },
+            ""OrgnlTxRef"": {
+            ""PmtTpInf"": {
+            ""SvcLvl"": { ""Cd"": ""SRTP"" },
+            ""LclInstrm"": { ""Prtry"": ""NOTPROVIDED"" }
+            },
+            ""RmtInf"": { ""Ustrd"": ""Payment for invoice 12345."" },
+            ""Cdtr"": {
+            ""Id"": { ""OrgId"": { ""Othr"": { ""Id"": ""TRX-ID-112233"", ""SchmeNm"": { ""Cd"": ""BOID"" } } } },
+            ""Nm"": ""Azienda Creditrice S.p.A.""
+            },
+            ""DbtrAgt"": { ""FinInstnId"": { ""BICFI"": ""MOCKSP04"" } },
+            ""CdtrAgt"": { ""FinInstnId"": { ""BICFI"": ""MOCKSP04"" } },
+            ""CdtrAcct"": { ""Id"": { ""IBAN"": ""IT12L0123456789012345678901"" } },
+            ""Amt"": { ""InstdAmt"": 450.75 },
+            ""ReqdExctnDt"": { ""Dt"": ""2026-02-20Z"" },
+            ""XpryDt"": { ""Dt"": ""2026-03-10Z"" } } } } ] } },
+            ""_links"": {
+            ""initialSepaRequestToPayUri"": {
+            ""href"": ""https://api-rtp-cb.cstar.pagopa.it/rtp/cb/requests/123"",
+            ""templated"": false } },
+            ""invalidField"": ""test"" }";
+            }</set-body>
+        </return-response>
+      </when>
       <otherwise>
         <return-response>
           <set-status code="201" reason="Created" />


### PR DESCRIPTION
### List of changes

Added two new mock policy cases in `src/srtp/api/test/mock_policy_epc.xml`, each tied to a newly generated fiscal code:

- **`BNCLCU85M15F205W`**: returns HTTP 201 with the same body structure as the reference case (`QBICLE31R41A110G`), but the `_links` field is **omitted** from the response body.
- **`RSSGNN92P20H501Z`**: returns HTTP 201 with the same body structure as the reference case (`QBICLE31R41A110G`), with `_links` present, but an additional unexpected field `"invalidField": "test"` is included at the top level of the response body.

### Motivation and context

These cases extend the EPC mock policy to cover negative/edge-case scenarios useful for integration testing:

1. A response missing the `_links` section — allows testing that consumers handle the absence of hypermedia links gracefully.
2. A response containing an unknown extra field — allows testing that consumers correctly ignore or reject unexpected fields in the payload.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [x] DEV
- [x] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

The two new fiscal codes (`BNCLCU85M15F205W`, `RSSGNN92P20H501Z`) are synthetic values generated solely for mock/test purposes and do not correspond to real individuals.

---

### If PR is partially applied, why? (reserved to mantainers)

N/A
