### PR TITLE
chore: [SRTP-1695] Updating tokens

### DIFF
--- a/src/srtp/api/pagopa/activation.yaml
+++ b/src/srtp/api/pagopa/activation.yaml
@@ -1256,8 +1256,8 @@ components:
       type: oauth2
       flows:
         clientCredentials:
-          tokenUrl: /token
-          refreshUrl: /token
+          tokenUrl: https://api-mcshared.cstar.pagopa.it/auth-itn/realms/srtp/protocol/openid-connect/token
+          refreshUrl: https://api-mcshared.cstar.pagopa.it/auth-itn/realms/srtp/protocol/openid-connect/token
           scopes:
             admin_rtp_activations: Grants full administrative access to all activations.
             write_rtp_activations: Grants permission to create, update, or delete activations.

--- a/src/srtp/api/pagopa/payees_registry.yaml
+++ b/src/srtp/api/pagopa/payees_registry.yaml
@@ -502,7 +502,7 @@ components:
       type: oauth2
       flows:
         clientCredentials:
-          tokenUrl: /token
-          refreshUrl: /token
+          tokenUrl: https://api-mcshared.cstar.pagopa.it/auth-itn/realms/srtp/protocol/openid-connect/token
+          refreshUrl: https://api-mcshared.cstar.pagopa.it/auth-itn/realms/srtp/protocol/openid-connect/token
           scopes:
             read_rtp_payees: Grants permission to read the RTP Payees registry.

--- a/src/srtp/api/pagopa/service_providers_registry.yaml
+++ b/src/srtp/api/pagopa/service_providers_registry.yaml
@@ -525,7 +525,7 @@ components:
       type: oauth2
       flows:
         clientCredentials:
-          tokenUrl: /token
-          refreshUrl: /token
+          tokenUrl: https://api-mcshared.cstar.pagopa.it/auth-itn/realms/srtp/protocol/openid-connect/token
+          refreshUrl: https://api-mcshared.cstar.pagopa.it/auth-itn/realms/srtp/protocol/openid-connect/token
           scopes:
             read_rtp_service_providers: Grants permission to read the list of RTP service providers.


### PR DESCRIPTION
### List of changes

Updated the OAuth2 `tokenUrl` and `refreshUrl` values from the placeholder `/token` to the actual Keycloak token endpoint across three OpenAPI spec files:

- `src/srtp/api/pagopa/activation.yaml`
- `src/srtp/api/pagopa/payees_registry.yaml`
- `src/srtp/api/pagopa/service_providers_registry.yaml`

The new URL for both fields is:
`https://api-mcshared.cstar.pagopa.it/auth-itn/realms/srtp/protocol/openid-connect/token`

### Motivation and context

The previous placeholder value `/token` was not a valid absolute URL and would cause authentication failures for consumers of the API spec trying to use the documented OAuth2 client credentials flow. This change replaces it with the correct Keycloak endpoint for the `srtp` realm, making the spec accurate and usable for tooling that auto-configures OAuth2 flows from the OpenAPI definition.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

Only the `securitySchemes` section of each YAML is affected — no API paths, schemas, or response models were modified. The change is purely to the OAuth2 token endpoint URL used in the spec documentation.

---

### If PR is partially applied, why? (reserved to mantainers)

N/A
