### PR TITLE
fix: [SRTP-1704] handle BackendConnectionFailure with APIM retry policy

### DIFF
--- a/src/srtp/05_api_policy.tf
+++ b/src/srtp/05_api_policy.tf
@@ -10,6 +10,7 @@ resource "azurerm_api_management_api_policy" "this" {
   xml_content = each.value.api_policy.xml_content
 
   depends_on = [
-    azurerm_api_management_api.this
+    azurerm_api_management_api.this,
+    azurerm_api_management_policy_fragment.this
   ]
 }

--- a/src/srtp/99_locals.tf
+++ b/src/srtp/99_locals.tf
@@ -50,7 +50,7 @@ locals {
       }
       api_policy = {
         xml_content = templatefile("./api/pagopa/activation_base_policy.xml", {
-          fragment_id = "rtp-validate-token-mcshared-v2"
+          fragment_id         = "rtp-validate-token-mcshared-v2"
           backend_fragment_id = "backend-retry"
         })
       }
@@ -88,7 +88,7 @@ locals {
       }
       api_policy = {
         xml_content = templatefile("./api/pagopa/payees_base_policy.xml", {
-          fragment_id = "rtp-validate-token-mcshared-v2"
+          fragment_id         = "rtp-validate-token-mcshared-v2"
           backend_fragment_id = "backend-retry"
         })
       }

--- a/src/srtp/99_locals.tf
+++ b/src/srtp/99_locals.tf
@@ -51,6 +51,7 @@ locals {
       api_policy = {
         xml_content = templatefile("./api/pagopa/activation_base_policy.xml", {
           fragment_id = "rtp-validate-token-mcshared-v2"
+          backend_fragment_id = "backend-retry"
         })
       }
       api_diagnostic = {
@@ -88,6 +89,7 @@ locals {
       api_policy = {
         xml_content = templatefile("./api/pagopa/payees_base_policy.xml", {
           fragment_id = "rtp-validate-token-mcshared-v2"
+          backend_fragment_id = "backend-retry"
         })
       }
       api_diagnostic = {
@@ -174,6 +176,11 @@ locals {
         display_name        = "RTP ITN Service Provider API"
         versioning_scheme   = "Header"
         version_header_name = "Version"
+      }
+      api_policy = {
+        xml_content = templatefile("./api/pagopa/send_base_policy.xml", {
+          backend_fragment_id = "backend-retry"
+        })
       }
     }
 
@@ -307,6 +314,11 @@ locals {
         mc_shared_base_url = local.mc_shared_base_url,
         apim_logger_name   = "${local.project}-apim-logger"
       })
+    },
+    backend-retry = {
+      description = "Retry on backend connection failure"
+      format      = "xml"
+      value       = file("./api_fragment/backend-retry.xml")
     }
   }
 

--- a/src/srtp/api/pagopa/activation_base_policy.xml
+++ b/src/srtp/api/pagopa/activation_base_policy.xml
@@ -16,7 +16,7 @@
         <include-fragment fragment-id="${fragment_id}" />
     </inbound>
     <backend>
-        <base />
+      <include-fragment fragment-id="${backend_fragment_id}" />
     </backend>
     <outbound>
         <base />

--- a/src/srtp/api/pagopa/payees_base_policy.xml
+++ b/src/srtp/api/pagopa/payees_base_policy.xml
@@ -16,7 +16,7 @@
     <include-fragment fragment-id="${fragment_id}" />
   </inbound>
   <backend>
-    <base />
+    <include-fragment fragment-id="${backend_fragment_id}" />
   </backend>
   <outbound>
     <base />

--- a/src/srtp/api/pagopa/send_base_policy.xml
+++ b/src/srtp/api/pagopa/send_base_policy.xml
@@ -1,0 +1,14 @@
+<policies>
+  <inbound>
+    <base />
+  </inbound>
+  <backend>
+    <include-fragment fragment-id="${backend_fragment_id}" />
+  </backend>
+  <outbound>
+    <base />
+  </outbound>
+  <on-error>
+    <base />
+  </on-error>
+</policies>

--- a/src/srtp/api_fragment/backend-retry.xml
+++ b/src/srtp/api_fragment/backend-retry.xml
@@ -1,0 +1,8 @@
+<fragment>
+  <retry condition="@(context.LastError?.Reason == &quot;BackendConnectionFailure&quot;)"
+    count="3"
+    interval="1"
+    first-fast-retry="true">
+    <forward-request buffer-request-body="true" />
+  </retry>
+</fragment>

--- a/src/srtp/api_product/base_policy.xml
+++ b/src/srtp/api_product/base_policy.xml
@@ -28,7 +28,12 @@
     </cors>
   </inbound>
   <backend>
-    <base />
+    <retry condition="@(context.LastError?.Reason == &quot;BackendConnectionFailure&quot;)"
+      count="3"
+      interval="1"
+      first-fast-retry="true">
+      <forward-request buffer-request-body="true" />
+    </retry>
   </backend>
   <outbound>
     <base />

--- a/src/srtp/api_product/base_policy.xml
+++ b/src/srtp/api_product/base_policy.xml
@@ -28,12 +28,7 @@
     </cors>
   </inbound>
   <backend>
-    <retry condition="@(context.LastError?.Reason == &quot;BackendConnectionFailure&quot;)"
-      count="3"
-      interval="1"
-      first-fast-retry="true">
-      <forward-request buffer-request-body="true" />
-    </retry>
+    <base />
   </backend>
   <outbound>
     <base />


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

- Added a new policy fragment `backend-retry` (`api_fragment/backend-retry.xml`) that wraps the `<forward-request>` call in a `<retry>` policy, retrying up to 3 times with a 1-second interval and fast first retry on `BackendConnectionFailure`.
- Registered the new fragment in the `policy_fragment` map inside `99_locals.tf`.
- Updated the following API base policies to include the `backend-retry` fragment in their `<backend>` section instead of `<base />`:
  - `api/pagopa/activation_base_policy.xml` (API: `rtp-activation`)
  - `api/pagopa/payees_base_policy.xml` (API: `rtp-payees`)
- Created a new API base policy `api/pagopa/send_base_policy.xml` and attached it to the `rtp-service-provider` API (which previously had no API-level policy), so that the retry behavior is applied to all its operations.
- Updated `99_locals.tf` to pass the `backend_fragment_id = "backend-retry"` parameter to the templates above.
- Added `azurerm_api_management_policy_fragment.this` to the `depends_on` of `azurerm_api_management_api_policy.this` in `05_api_policy.tf`, to ensure the fragment is provisioned before any API policy that references it.

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Some backend calls were occasionally failing due to transient `BackendConnectionFailure` errors at the APIM level, with no automatic retry in place. Adding a retry directly on the APIM gateway makes the platform more resilient to transient connection issues without requiring changes on the consumer side. Currently it is enabled on:

- `rtp-activation`
- `rtp-payees`
- `rtp-service-provider`

### Type of changes

- [x] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [x] DEV
- [x] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unit wanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
