### PR TITLE
chore: [SRTP-1808] Add   GpdErrorWithRtpResponse to OpenApi

### DIFF
--- a/src/srtp/api/pagopa/send.openapi.yaml
+++ b/src/srtp/api/pagopa/send.openapi.yaml
@@ -850,7 +850,7 @@ components:
         code: "01000000F"
         description: "Wrong party identifier"
         rtp:
-          resourceID: "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+          resourceId: "3fa85f64-5717-4562-b3fc-2c963f66afa6"
           noticeNumber: "311111111112222123"
           amount: 1050.75
           description: "TARI 2025 payment"

--- a/src/srtp/api/pagopa/send.openapi.yaml
+++ b/src/srtp/api/pagopa/send.openapi.yaml
@@ -271,6 +271,9 @@ paths:
         "415":
           #description: Unsupported media type. Did you provide application/json?
           $ref: '#/components/responses/GenericError'
+        "422":
+          #description: Unprocessable Entity - business rules validation failed.
+          $ref: '#/components/responses/GpdErrorWithRtpResponse'
         "429":
           #description: Too many request.
           $ref: '#/components/responses/GenericError'
@@ -828,6 +831,47 @@ components:
         code: "01000000F"
         description: "Wrong party identifier"
 
+    GpdErrorWithRtp:
+      type: object
+      description: GPD error response containing both business error context and the associated RTP state.
+      additionalProperties: false
+      properties:
+        code:
+          $ref: '#/components/schemas/ErrorCode'
+        description:
+          $ref: '#/components/schemas/ErrorDescription'
+        rtp:
+          $ref: '#/components/schemas/Rtp'
+      required:
+        - code
+        - description
+        - rtp
+      example:
+        code: "01000000F"
+        description: "Wrong party identifier"
+        rtp:
+          resourceID: "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+          noticeNumber: "311111111112222123"
+          amount: 1050.75
+          description: "TARI 2025 payment"
+          expiryDate: "2025-12-31"
+          payerName: "Mario Rossi"
+          payerId: "RSSMRA85T10A562S"
+          payeeName: "Comune di Roma"
+          payeeId: "77777777777"
+          subject: "TARI 2025"
+          savingDateTime: "2025-06-06T08:40:16.781Z"
+          serviceProviderDebtor: "FAKESP01"
+          serviceProviderCreditor: "PA123456789"
+          iban: "IT60X0542811101000000123456"
+          payTrxRef: "ABC/124"
+          flgConf: "flgConf"
+          status: SENT
+          events:
+            - timestamp: "2025-06-06T08:40:16.781Z"
+              precStatus: "CREATED"
+              triggerEvent: "CREATE_RTP"
+
     GpdMessage:
       type: object
       description: >
@@ -1278,6 +1322,15 @@ components:
             type: string
             pattern: "^[ -~]{0,65535}$"
             maxLength: 65535
+
+    GpdErrorWithRtpResponse:
+      description: >
+        Unprocessable Entity. Returned when business rules validation fails.
+        The response payload wraps the error code, description, and the active RTP state context.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/GpdErrorWithRtp'
 
 
 

--- a/src/srtp/api/pagopa/send.openapi.yaml
+++ b/src/srtp/api/pagopa/send.openapi.yaml
@@ -1327,6 +1327,30 @@ components:
       description: >
         Unprocessable Entity. Returned when business rules validation fails.
         The response payload wraps the error code, description, and the active RTP state context.
+      headers:
+        Access-Control-Allow-Origin:
+          description: |
+            Indicates whether the response can be shared with requesting code
+            from the given origin.
+          required: false
+          schema:
+            $ref: '#/components/schemas/AccessControlAllowOrigin'
+        RateLimit-Limit:
+          description: The number of allowed requests in the current period.
+          required: false
+          schema:
+            $ref: '#/components/schemas/RateLimitLimit'
+        RateLimit-Reset:
+          description: The number of seconds left in the current period
+          required: false
+          schema:
+            $ref: '#/components/schemas/RateLimitReset'
+        Retry-After:
+          description: |
+            The number of seconds to wait before allowing a follow-up request.
+          required: false
+          schema:
+            $ref: '#/components/schemas/RetryAfter'
       content:
         application/json:
           schema:


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

- Added the `GpdErrorWithRtp` schema to define error responses that include the RTP state.
- Added the `GpdErrorWithRtpResponse` response component.
- Updated the `422 Unprocessable Entity` response in `send.openapi.yaml` to reference the new `GpdErrorWithRtpResponse` payload instead of a generic description.

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

To include both the RTP payload and the error message during a `422` response.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [x] DEV
- [x] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
