### PR TITLE
fix: [SRTP-1858] Add regex for foreign fiscal code

### DIFF
--- a/src/srtp/api/pagopa/activation.yaml
+++ b/src/srtp/api/pagopa/activation.yaml
@@ -744,7 +744,7 @@ components:
 
         It is used as identifier of the Payer (P009) and of the Payee (E005).
       type: string
-      pattern: "^(([A-Z]{6}\\d{2}[A-Z]\\d{2}[A-Z]\\d{3}[A-Z])|(\\d{11}))$"
+      pattern: "^(([A-Z]{6}\\d{2}[A-Z]\\d{2}([A-Y]\\d{3}|Z[A-Z0-9]{3})[A-Z])|(\\d{11}))$"
       minLength: 11
       maxLength: 16
       example: "RSSMRA85T10A562S"

--- a/src/srtp/api/pagopa/send.openapi.yaml
+++ b/src/srtp/api/pagopa/send.openapi.yaml
@@ -535,7 +535,7 @@ components:
     PayerId:
       type: string
       description: "The id of the recipient of the request to pay. The id is the fiscal code"
-      pattern: "^(([A-Z]{6}\\d{2}[A-Z]\\d{2}[A-Z]\\d{3}[A-Z])|(\\d{11}))$"
+      pattern: "^(([A-Z]{6}\\d{2}[A-Z]\\d{2}([A-Y]\\d{3}|Z[A-Z0-9]{3})[A-Z])|(\\d{11}))$"
       example: "ABCDEF12G34H567I"
 
     PayeeId:
@@ -660,7 +660,7 @@ components:
           type: string
           minLength: 11
           maxLength: 16
-          pattern: "^(([A-Z]{6}\\d{2}[A-Z]\\d{2}[A-Z]\\d{3}[A-Z])|(\\d{11}))$"
+          pattern: "^(([A-Z]{6}\\d{2}[A-Z]\\d{2}([A-Y]\\d{3}|Z[A-Z0-9]{3})[A-Z])|(\\d{11}))$"
           example: "RSSMRA85T10A562S"
         payeeName:
           type: string
@@ -909,7 +909,7 @@ components:
           pattern: "^(\\d{11}|\\d{16})$"
         debtor_tax_code:
           type: string
-          pattern: "^(([A-Z]{6}\\d{2}[A-Z]\\d{2}[A-Z]\\d{3}[A-Z])|(\\d{11}))$"
+          pattern: "^(([A-Z]{6}\\d{2}[A-Z]\\d{2}([A-Y]\\d{3}|Z[A-Z0-9]{3})[A-Z])|(\\d{11}))$"
         nav:
           type: string
           minLength: 15

--- a/src/srtp/api/pagopa/takeover.yaml
+++ b/src/srtp/api/pagopa/takeover.yaml
@@ -93,7 +93,7 @@ components:
 
             It is used as identifier of the Payer (P009) and of the Payee (E005).
           type: string
-          pattern: "^(([A-Z]{6}\\d{2}[A-Z]\\d{2}[A-Z]\\d{3}[A-Z])|(\\d{11}))$"
+          pattern: "^(([A-Z]{6}\\d{2}[A-Z]\\d{2}([A-Y]\\d{3}|Z[A-Z0-9]{3})[A-Z])|(\\d{11}))$"
           minLength: 11
           maxLength: 16
           example: "RSSMRA85T10A562S"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

- Updated the fiscal code regex pattern in send.openapi.yaml (PayerId, Rtp.payerId, GpdMessage.debtor_tax_code).
- New pattern: ^(([A-Z]{6}\d{2}[A-Z]\d{2}([A-Y]\d{3}|Z[A-Z0-9]{3})[A-Z])|(\d{11}))$

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

The previous regex only accepted Italian-resident fiscal codes. This change updates the validation to correctly accept foreign nationals' fiscal codes (which use a Z followed by alphanumeric characters for the municipality code).

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [x] DEV
- [x] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
