### PR TITLE
fix: [SRTP-1865] Improve OpenAPI error responses with HTTP-status-specific named components

### DIFF
--- a/src/srtp/api/epc/callback.openapi.yaml
+++ b/src/srtp/api/epc/callback.openapi.yaml
@@ -62,6 +62,10 @@ paths:
           $ref: '#/components/responses/BadRequest'
         "403":
           $ref: '#/components/responses/Forbidden'
+        "415":
+          $ref: '#/components/responses/UnsupportedMediaType'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
 
   /cancel:
     post:
@@ -84,6 +88,10 @@ paths:
           $ref: '#/components/responses/BadRequest'
         "403":
           $ref: '#/components/responses/Forbidden'
+        "415":
+          $ref: '#/components/responses/UnsupportedMediaType'
+        "500":
+          $ref: '#/components/responses/InternalServerError'
 
 components:
   schemas:
@@ -3597,6 +3605,17 @@ components:
               - $ref: '#/components/schemas/ErrorModelType2'
     TooManyRequests:
       description: The client has sent too many requests in a given amount of time (“rate limiting”) (HTTP429)
+      headers:
+        Correlation:
+          $ref: '#/components/headers/X-Request-ID'
+      content:
+        application/json:
+          schema:
+            oneOf:
+              - $ref: '#/components/schemas/ErrorModel'
+              - $ref: '#/components/schemas/ErrorModelType2'
+    InternalServerError:
+      description: An unexpected error occurred on the server side (HTTP500).
       headers:
         Correlation:
           $ref: '#/components/headers/X-Request-ID'

--- a/src/srtp/api/epc/callback.openapi.yaml
+++ b/src/srtp/api/epc/callback.openapi.yaml
@@ -186,10 +186,6 @@ components:
           type: string
           format: date-time
           example: "2026-05-26T08:51:22.506+00:00"
-        path:
-          type: string
-          maxLength: 140
-          example: "/send"
         status:
           type: integer
           format: int32
@@ -198,6 +194,26 @@ components:
           type: string
           maxLength: 140
           example: "Bad Request"
+        exception:
+          type: string
+          maxLength: 140
+          description: The class name of the root exception (if configured).
+        message:
+          type: string
+          maxLength: 140
+          description: The exception message (if configured).
+        errors:
+          type: array
+          description: Any ObjectErrors from a BindingResult or MethodValidationResult exception (if configured).
+          items:
+            type: object
+        trace:
+          type: string
+          description: The exception stack trace (if configured).
+        path:
+          type: string
+          maxLength: 140
+          example: "/send"
         requestId:
           type: string
           maxLength: 140

--- a/src/srtp/api/epc/callback.openapi.yaml
+++ b/src/srtp/api/epc/callback.openapi.yaml
@@ -58,12 +58,10 @@ paths:
       responses:
         "200":
           description: OK - Our server has received and accepted the client's notification.
-        "403":
-          description: Forbidden - The client is not authorized to call this endpoint.
-          $ref: '#/components/responses/Unauthorized'
         "400":
-          description: Bad Request - The request sent by the client is invalid.
           $ref: '#/components/responses/BadRequest'
+        "403":
+          $ref: '#/components/responses/Forbidden'
 
   /cancel:
     post:
@@ -82,12 +80,10 @@ paths:
       responses:
         "200":
           description: OK - the callback server accepts the callback.
-        "403":
-          description: Forbidden - The client is not authorized to call this endpoint.
-          $ref: '#/components/responses/Unauthorized'
         "400":
-          description: Bad Request - The request sent by the client is invalid.
           $ref: '#/components/responses/BadRequest'
+        "403":
+          $ref: '#/components/responses/Forbidden'
 
 components:
   schemas:
@@ -174,6 +170,36 @@ components:
       required:
       - status
       - message
+    ErrorModelType2:
+      type: object
+      description: Error response format returned by the Spring WebFlux gateway layer.
+      properties:
+        timestamp:
+          type: string
+          format: date-time
+          example: "2026-05-26T08:51:22.506+00:00"
+        path:
+          type: string
+          maxLength: 140
+          example: "/send"
+        status:
+          type: integer
+          format: int32
+          example: 400
+        error:
+          type: string
+          maxLength: 140
+          example: "Bad Request"
+        requestId:
+          type: string
+          maxLength: 140
+          example: "b280c067-21973"
+      required:
+      - timestamp
+      - path
+      - status
+      - error
+      - requestId
     ResourceId:
       type: string
     GenericHalLink:
@@ -3482,7 +3508,9 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/ErrorModel'
+            oneOf:
+              - $ref: '#/components/schemas/ErrorModel'
+              - $ref: '#/components/schemas/ErrorModelType2'
     Unauthorized:
       description: Indicates that the request requires user authentication information. The client MAY repeat the request with a suitable Authorization header field (HTTP401).
       headers:
@@ -3491,7 +3519,20 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/ErrorModel'
+            oneOf:
+              - $ref: '#/components/schemas/ErrorModel'
+              - $ref: '#/components/schemas/ErrorModelType2'
+    Forbidden:
+      description: The client is not authorized to call this endpoint (HTTP403).
+      headers:
+        Correlation:
+          $ref: '#/components/headers/X-Request-ID'
+      content:
+        application/json:
+          schema:
+            oneOf:
+              - $ref: '#/components/schemas/ErrorModel'
+              - $ref: '#/components/schemas/ErrorModelType2'
     NotFound:
       description: The requested resource was not found (HTTP404).
       headers:
@@ -3500,7 +3541,9 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/ErrorModel'
+            oneOf:
+              - $ref: '#/components/schemas/ErrorModel'
+              - $ref: '#/components/schemas/ErrorModelType2'
     NotAcceptable:
       description: The server doesn’t find any content that conforms to the criteria given by the user agent in the Accept header sent in the request. (HTTP406).
       headers:
@@ -3509,7 +3552,9 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/ErrorModel'
+            oneOf:
+              - $ref: '#/components/schemas/ErrorModel'
+              - $ref: '#/components/schemas/ErrorModelType2'
     Conflict:
       description: |
         The request could not be completed due to a conflict with the current state of the resource (e.g. pre-existing resource). (HTTP409)
@@ -3523,7 +3568,9 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/ErrorModel'
+            oneOf:
+              - $ref: '#/components/schemas/ErrorModel'
+              - $ref: '#/components/schemas/ErrorModelType2'
     Gone:
       description: |
         The requested resource is no longer available at the server. (HTTP410)
@@ -3534,7 +3581,9 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/ErrorModel'
+            oneOf:
+              - $ref: '#/components/schemas/ErrorModel'
+              - $ref: '#/components/schemas/ErrorModelType2'
     UnsupportedMediaType:
       description: The media-type in Content-type of the request is not supported by the server. (HTTP415)
       headers:
@@ -3543,7 +3592,9 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/ErrorModel'
+            oneOf:
+              - $ref: '#/components/schemas/ErrorModel'
+              - $ref: '#/components/schemas/ErrorModelType2'
     TooManyRequests:
       description: The client has sent too many requests in a given amount of time (“rate limiting”) (HTTP429)
       headers:
@@ -3552,7 +3603,9 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/ErrorModel'
+            oneOf:
+              - $ref: '#/components/schemas/ErrorModel'
+              - $ref: '#/components/schemas/ErrorModelType2'
   parameters:
     Idempotency:
       name: Idempotency-key

--- a/src/srtp/api/pagopa/activation.yaml
+++ b/src/srtp/api/pagopa/activation.yaml
@@ -94,12 +94,6 @@ paths:
           #  - 01011005E: Invalid scope
           #  - 01011006F: Mismatch between Payer's RTP Service Provider ID and token subject
           $ref: '#/components/responses/ForbiddenError'
-        "406":
-          # The 'Accept' header is not supported.
-
-          #  Possible error codes:
-          #  - 01021010E: Unsupported accept header
-          $ref: '#/components/responses/NotAcceptableError'
         "409":
           # A conflict occurred. An activation for this Payer already exists. The `Location` header
           # in the response points to the existing, conflicting resource.
@@ -179,13 +173,6 @@ paths:
           #  - 01011004E: Insufficient permissions
           #  - 01011005E: Invalid scope
           $ref: '#/components/responses/ForbiddenError'
-        "406":
-          #description: |
-          #  Not acceptable. Did you require application/json?
-
-          #  Possible error codes:
-          #  - 01021010E: Unsupported accept header
-          $ref: '#/components/responses/NotAcceptableError'
         "429":
           #description: |
           #  Too many requests.
@@ -258,13 +245,6 @@ paths:
           #  - 01041000E: Activation not found
           #  - 01041001E: Activation not visible to non-admin
           $ref: '#/components/responses/NotFoundError'
-        "406":
-          #description: |
-          #  Not acceptable. Did you require application/json?
-
-          #  Possible error codes:
-          #  - 01021010E: Unsupported accept header
-          $ref: '#/components/responses/NotAcceptableError'
         "429":
           #description: |
           #  Too many requests.
@@ -337,13 +317,6 @@ paths:
           #  - 01041000E: Activation not found
           #  - 01041001E: Activation not visible to non-admin
           $ref: '#/components/responses/NotFoundError'
-        "406":
-          #description: |
-          #  Not acceptable. Did you require application/json?
-
-          #  Possible error codes:
-          #  - 01021010E: Unsupported accept header
-          $ref: '#/components/responses/NotAcceptableError'
         "429":
           #description: |
           #  Too many requests
@@ -415,21 +388,6 @@ paths:
           #  Possible error codes:
           #  - 01041000E: Activation not found
           $ref: '#/components/responses/NotFoundError'
-        "406":
-          #description: |
-          #  Not acceptable. Did you require application/json?
-
-          #  Possible error codes:
-          #  - 01021010E: Unsupported accept header
-          $ref: '#/components/responses/NotAcceptableError'
-        "415":
-          #description: |
-          #  Unsupported media type. Did you provide application/json?
-
-          #  Possible error codes:
-          #  - 01021011E: Unsupported content type
-          #  - 01021012E: Invalid content encoding
-          $ref: '#/components/responses/UnsupportedMediaTypeError'
         "429":
           #description: |
           #  Too many requests
@@ -500,13 +458,6 @@ paths:
           #description: |
           #  Not found.
           $ref: '#/components/responses/NotFoundError'
-        "406":
-          #description: |
-          #  Not acceptable. Did you require application/json?
-
-          #  Possible error codes:
-          #  - 01021010F: Unsupported accept header
-          $ref: '#/components/responses/NotAcceptableError'
         "429":
           #description: |
           #  Too many requests.
@@ -1307,42 +1258,6 @@ components:
 
     NotFoundError:
       description: Not found. The requested activation does not exist or is not visible to the caller.
-      headers:
-        Access-Control-Allow-Origin:
-          description: |
-            Indicates whether the response can be shared with requesting code
-            from the given origin.
-          required: false
-          schema:
-            $ref: '#/components/schemas/AccessControlAllowOrigin'
-        RateLimit-Limit:
-          description: The number of allowed requests in the current period.
-          required: false
-          schema:
-            $ref: '#/components/schemas/RateLimitLimit'
-        RateLimit-Reset:
-          description: The number of seconds left in the current period.
-          required: false
-          schema:
-            $ref: '#/components/schemas/RateLimitReset'
-        Retry-After:
-          description: |
-            The number of seconds to wait before allowing a follow-up request.
-          required: false
-          schema:
-            $ref: '#/components/schemas/RetryAfter'
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/Errors'
-        text/*:
-          schema:
-            type: string
-            pattern: "^[ -~]{0,65535}$"
-            maxLength: 65535
-
-    NotAcceptableError:
-      description: Not acceptable. The Accept header specifies a media type not supported by this API.
       headers:
         Access-Control-Allow-Origin:
           description: |

--- a/src/srtp/api/pagopa/activation.yaml
+++ b/src/srtp/api/pagopa/activation.yaml
@@ -1035,22 +1035,11 @@ components:
       description: Response returned when RTP activation data is requested.
       headers:
         Access-Control-Allow-Origin:
-          description: |
-            Indicates whether the response can be shared with requesting code
-            from the given origin.
-          required: false
-          schema:
-            $ref: '#/components/schemas/AccessControlAllowOrigin'
+          $ref: '#/components/headers/AccessControlAllowOrigin'
         RateLimit-Limit:
-          description: The number of allowed requests in the current period
-          required: false
-          schema:
-            $ref: '#/components/schemas/RateLimitLimit'
+          $ref: '#/components/headers/RateLimitLimit'
         RateLimit-Reset:
-          description: The number of seconds left in the current period
-          required: false
-          schema:
-            $ref: '#/components/schemas/RateLimitReset'
+          $ref: '#/components/headers/RateLimitReset'
       content:
         application/json:
           schema:
@@ -1060,22 +1049,11 @@ components:
       description: Response returned when a RTP activation is requested.
       headers:
         Access-Control-Allow-Origin:
-          description: |
-            Indicates whether the response can be shared with requesting code
-            from the given origin.
-          required: false
-          schema:
-            $ref: '#/components/schemas/AccessControlAllowOrigin'
+          $ref: '#/components/headers/AccessControlAllowOrigin'
         RateLimit-Limit:
-          description: The number of allowed requests in the current period.
-          required: false
-          schema:
-            $ref: '#/components/schemas/RateLimitLimit'
+          $ref: '#/components/headers/RateLimitLimit'
         RateLimit-Reset:
-          description: The number of seconds left in the current period.
-          required: false
-          schema:
-            $ref: '#/components/schemas/RateLimitReset'
+          $ref: '#/components/headers/RateLimitReset'
         Location:
           description: URL of the activation resource.
           required: true
@@ -1086,22 +1064,11 @@ components:
       description: Conflict. An activation for this Payer already exists. The Location header points to the existing resource.
       headers:
         Access-Control-Allow-Origin:
-          description: |
-            Indicates whether the response can be shared with requesting code
-            from the given origin.
-          required: false
-          schema:
-            $ref: '#/components/schemas/AccessControlAllowOrigin'
+          $ref: '#/components/headers/AccessControlAllowOrigin'
         RateLimit-Limit:
-          description: The number of allowed requests in the current period.
-          required: false
-          schema:
-            $ref: '#/components/schemas/RateLimitLimit'
+          $ref: '#/components/headers/RateLimitLimit'
         RateLimit-Reset:
-          description: The number of seconds left in the current period.
-          required: false
-          schema:
-            $ref: '#/components/schemas/RateLimitReset'
+          $ref: '#/components/headers/RateLimitReset'
         Location:
           description: URL to do a takeover on an existing activation user.
           required: true
@@ -1116,28 +1083,13 @@ components:
       description: Response returned when an unexpected error occurred.
       headers:
         Access-Control-Allow-Origin:
-          description: |
-            Indicates whether the response can be shared with requesting code
-            from the given origin.
-          required: false
-          schema:
-            $ref: '#/components/schemas/AccessControlAllowOrigin'
+          $ref: '#/components/headers/AccessControlAllowOrigin'
         RateLimit-Limit:
-          description: The number of allowed requests in the current period.
-          required: false
-          schema:
-            $ref: '#/components/schemas/RateLimitLimit'
+          $ref: '#/components/headers/RateLimitLimit'
         RateLimit-Reset:
-          description: The number of seconds left in the current period
-          required: false
-          schema:
-            $ref: '#/components/schemas/RateLimitReset'
+          $ref: '#/components/headers/RateLimitReset'
         Retry-After:
-          description: |
-            The number of seconds to wait before allowing a follow-up request.
-          required: false
-          schema:
-            $ref: '#/components/schemas/RetryAfter'
+          $ref: '#/components/headers/RetryAfter'
       content:
         application/json:
           schema:
@@ -1152,28 +1104,13 @@ components:
       description: Bad request. The request was malformed or contained invalid parameters.
       headers:
         Access-Control-Allow-Origin:
-          description: |
-            Indicates whether the response can be shared with requesting code
-            from the given origin.
-          required: false
-          schema:
-            $ref: '#/components/schemas/AccessControlAllowOrigin'
+          $ref: '#/components/headers/AccessControlAllowOrigin'
         RateLimit-Limit:
-          description: The number of allowed requests in the current period.
-          required: false
-          schema:
-            $ref: '#/components/schemas/RateLimitLimit'
+          $ref: '#/components/headers/RateLimitLimit'
         RateLimit-Reset:
-          description: The number of seconds left in the current period.
-          required: false
-          schema:
-            $ref: '#/components/schemas/RateLimitReset'
+          $ref: '#/components/headers/RateLimitReset'
         Retry-After:
-          description: |
-            The number of seconds to wait before allowing a follow-up request.
-          required: false
-          schema:
-            $ref: '#/components/schemas/RetryAfter'
+          $ref: '#/components/headers/RetryAfter'
       content:
         application/json:
           schema:
@@ -1188,28 +1125,13 @@ components:
       description: Unauthorized. Access token is missing or invalid.
       headers:
         Access-Control-Allow-Origin:
-          description: |
-            Indicates whether the response can be shared with requesting code
-            from the given origin.
-          required: false
-          schema:
-            $ref: '#/components/schemas/AccessControlAllowOrigin'
+          $ref: '#/components/headers/AccessControlAllowOrigin'
         RateLimit-Limit:
-          description: The number of allowed requests in the current period.
-          required: false
-          schema:
-            $ref: '#/components/schemas/RateLimitLimit'
+          $ref: '#/components/headers/RateLimitLimit'
         RateLimit-Reset:
-          description: The number of seconds left in the current period.
-          required: false
-          schema:
-            $ref: '#/components/schemas/RateLimitReset'
+          $ref: '#/components/headers/RateLimitReset'
         Retry-After:
-          description: |
-            The number of seconds to wait before allowing a follow-up request.
-          required: false
-          schema:
-            $ref: '#/components/schemas/RetryAfter'
+          $ref: '#/components/headers/RetryAfter'
       content:
         application/json:
           schema:
@@ -1224,28 +1146,13 @@ components:
       description: Forbidden. The caller has insufficient permissions or the provided identity does not match the token subject.
       headers:
         Access-Control-Allow-Origin:
-          description: |
-            Indicates whether the response can be shared with requesting code
-            from the given origin.
-          required: false
-          schema:
-            $ref: '#/components/schemas/AccessControlAllowOrigin'
+          $ref: '#/components/headers/AccessControlAllowOrigin'
         RateLimit-Limit:
-          description: The number of allowed requests in the current period.
-          required: false
-          schema:
-            $ref: '#/components/schemas/RateLimitLimit'
+          $ref: '#/components/headers/RateLimitLimit'
         RateLimit-Reset:
-          description: The number of seconds left in the current period.
-          required: false
-          schema:
-            $ref: '#/components/schemas/RateLimitReset'
+          $ref: '#/components/headers/RateLimitReset'
         Retry-After:
-          description: |
-            The number of seconds to wait before allowing a follow-up request.
-          required: false
-          schema:
-            $ref: '#/components/schemas/RetryAfter'
+          $ref: '#/components/headers/RetryAfter'
       content:
         application/json:
           schema:
@@ -1260,28 +1167,13 @@ components:
       description: Not found. The requested activation does not exist or is not visible to the caller.
       headers:
         Access-Control-Allow-Origin:
-          description: |
-            Indicates whether the response can be shared with requesting code
-            from the given origin.
-          required: false
-          schema:
-            $ref: '#/components/schemas/AccessControlAllowOrigin'
+          $ref: '#/components/headers/AccessControlAllowOrigin'
         RateLimit-Limit:
-          description: The number of allowed requests in the current period.
-          required: false
-          schema:
-            $ref: '#/components/schemas/RateLimitLimit'
+          $ref: '#/components/headers/RateLimitLimit'
         RateLimit-Reset:
-          description: The number of seconds left in the current period.
-          required: false
-          schema:
-            $ref: '#/components/schemas/RateLimitReset'
+          $ref: '#/components/headers/RateLimitReset'
         Retry-After:
-          description: |
-            The number of seconds to wait before allowing a follow-up request.
-          required: false
-          schema:
-            $ref: '#/components/schemas/RetryAfter'
+          $ref: '#/components/headers/RetryAfter'
       content:
         application/json:
           schema:
@@ -1296,28 +1188,13 @@ components:
       description: Unsupported media type. The Content-Type header specifies a format not supported by this API.
       headers:
         Access-Control-Allow-Origin:
-          description: |
-            Indicates whether the response can be shared with requesting code
-            from the given origin.
-          required: false
-          schema:
-            $ref: '#/components/schemas/AccessControlAllowOrigin'
+          $ref: '#/components/headers/AccessControlAllowOrigin'
         RateLimit-Limit:
-          description: The number of allowed requests in the current period.
-          required: false
-          schema:
-            $ref: '#/components/schemas/RateLimitLimit'
+          $ref: '#/components/headers/RateLimitLimit'
         RateLimit-Reset:
-          description: The number of seconds left in the current period.
-          required: false
-          schema:
-            $ref: '#/components/schemas/RateLimitReset'
+          $ref: '#/components/headers/RateLimitReset'
         Retry-After:
-          description: |
-            The number of seconds to wait before allowing a follow-up request.
-          required: false
-          schema:
-            $ref: '#/components/schemas/RetryAfter'
+          $ref: '#/components/headers/RetryAfter'
       content:
         application/json:
           schema:
@@ -1332,28 +1209,13 @@ components:
       description: Too many requests. The client has exceeded the rate limit or quota.
       headers:
         Access-Control-Allow-Origin:
-          description: |
-            Indicates whether the response can be shared with requesting code
-            from the given origin.
-          required: false
-          schema:
-            $ref: '#/components/schemas/AccessControlAllowOrigin'
+          $ref: '#/components/headers/AccessControlAllowOrigin'
         RateLimit-Limit:
-          description: The number of allowed requests in the current period.
-          required: false
-          schema:
-            $ref: '#/components/schemas/RateLimitLimit'
+          $ref: '#/components/headers/RateLimitLimit'
         RateLimit-Reset:
-          description: The number of seconds left in the current period.
-          required: false
-          schema:
-            $ref: '#/components/schemas/RateLimitReset'
+          $ref: '#/components/headers/RateLimitReset'
         Retry-After:
-          description: |
-            The number of seconds to wait before allowing a follow-up request.
-          required: false
-          schema:
-            $ref: '#/components/schemas/RetryAfter'
+          $ref: '#/components/headers/RetryAfter'
       content:
         application/json:
           schema:
@@ -1368,28 +1230,13 @@ components:
       description: Internal server error. An unexpected error occurred on the server side.
       headers:
         Access-Control-Allow-Origin:
-          description: |
-            Indicates whether the response can be shared with requesting code
-            from the given origin.
-          required: false
-          schema:
-            $ref: '#/components/schemas/AccessControlAllowOrigin'
+          $ref: '#/components/headers/AccessControlAllowOrigin'
         RateLimit-Limit:
-          description: The number of allowed requests in the current period.
-          required: false
-          schema:
-            $ref: '#/components/schemas/RateLimitLimit'
+          $ref: '#/components/headers/RateLimitLimit'
         RateLimit-Reset:
-          description: The number of seconds left in the current period.
-          required: false
-          schema:
-            $ref: '#/components/schemas/RateLimitReset'
+          $ref: '#/components/headers/RateLimitReset'
         Retry-After:
-          description: |
-            The number of seconds to wait before allowing a follow-up request.
-          required: false
-          schema:
-            $ref: '#/components/schemas/RetryAfter'
+          $ref: '#/components/headers/RetryAfter'
       content:
         application/json:
           schema:
@@ -1404,47 +1251,53 @@ components:
       description: No content response.
       headers:
         Access-Control-Allow-Origin:
-          description: |
-            Indicates whether the response can be shared with requesting code
-            from the given origin.
-          required: false
-          schema:
-            $ref: '#/components/schemas/AccessControlAllowOrigin'
+          $ref: '#/components/headers/AccessControlAllowOrigin'
         RateLimit-Limit:
-          description: The number of allowed requests in the current period.
-          required: false
-          schema:
-            $ref: '#/components/schemas/RateLimitLimit'
+          $ref: '#/components/headers/RateLimitLimit'
         RateLimit-Reset:
-          description: The number of seconds left in the current period.
-          required: false
-          schema:
-            $ref: '#/components/schemas/RateLimitReset'
+          $ref: '#/components/headers/RateLimitReset'
 
     PageOfActivations:
       description: Response to the request to get RTP activations.
       headers:
         Access-Control-Allow-Origin:
-          description: |
-            Indicates whether the response can be shared with requesting code
-            from the given origin.
-          required: false
-          schema:
-            $ref: '#/components/schemas/AccessControlAllowOrigin'
+          $ref: '#/components/headers/AccessControlAllowOrigin'
         RateLimit-Limit:
-          description: The number of allowed requests in the current period.
-          required: false
-          schema:
-            $ref: '#/components/schemas/RateLimitLimit'
+          $ref: '#/components/headers/RateLimitLimit'
         RateLimit-Reset:
-          description: The number of seconds left in the current period.
-          required: false
-          schema:
-            $ref: '#/components/schemas/RateLimitReset'
+          $ref: '#/components/headers/RateLimitReset'
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/PageOfActivations'
+
+  # ============================================================================
+  # Headers.
+  # ============================================================================
+  headers:
+    AccessControlAllowOrigin:
+      description: |
+        Indicates whether the response can be shared with requesting code
+        from the given origin.
+      required: false
+      schema:
+        $ref: '#/components/schemas/AccessControlAllowOrigin'
+    RateLimitLimit:
+      description: The number of allowed requests in the current period.
+      required: false
+      schema:
+        $ref: '#/components/schemas/RateLimitLimit'
+    RateLimitReset:
+      description: The number of seconds left in the current period.
+      required: false
+      schema:
+        $ref: '#/components/schemas/RateLimitReset'
+    RetryAfter:
+      description: |
+        The number of seconds to wait before allowing a follow-up request.
+      required: false
+      schema:
+        $ref: '#/components/schemas/RetryAfter'
 
   # ============================================================================
   # Security schemes.

--- a/src/srtp/api/pagopa/activation.yaml
+++ b/src/srtp/api/pagopa/activation.yaml
@@ -75,7 +75,7 @@ paths:
           #  - 01021003E: Invalid RTP Service Provider ID format
           #  - 01021004E: Invalid request payload structure
           #  - 01021009E: Required header missing
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/BadRequestError'
         "401":
           # Authentication failed (e.g., invalid or expired token).
 
@@ -84,7 +84,7 @@ paths:
           #  - 01011001E: Invalid token format
           #  - 01011002E: Expired token
           #  - 01011003E: Invalid signature
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/UnauthorizedError'
         "403":
           # Authorization failed. The caller has insufficient permissions or the Service Provider ID in the
           # request does not match the identity in the authentication token.
@@ -93,13 +93,13 @@ paths:
           #  - 01011004E: Insufficient permissions
           #  - 01011005E: Invalid scope
           #  - 01011006F: Mismatch between Payer's RTP Service Provider ID and token subject
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/ForbiddenError'
         "406":
           # The 'Accept' header is not supported.
 
           #  Possible error codes:
           #  - 01021010E: Unsupported accept header
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/NotAcceptableError'
         "409":
           # A conflict occurred. An activation for this Payer already exists. The `Location` header
           # in the response points to the existing, conflicting resource.
@@ -114,21 +114,21 @@ paths:
           #  Possible error codes:
           #  - 01021011E: Unsupported content type
           #  - 01021012E: Invalid content encoding
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/UnsupportedMediaTypeError'
         "429":
           # The client has sent too many requests.
 
           #  Possible error codes:
           #  - 01051000E: Rate limit exceeded
           #  - 01051001E: Quota exceeded
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/TooManyRequestsError'
         "500":
           # An unexpected internal server error occurred.
 
           #  Possible error codes:
           #  - 01091000F: Internal server error
           #  - 01091001F: Database error
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/InternalServerError'
         default:
           #description: Unexpected error.
           $ref: '#/components/responses/Error'
@@ -160,7 +160,7 @@ paths:
           #  - 01021005E: Invalid page parameter
           #  - 01021006E: Invalid size parameter
           #  - 01021009E: Required header missing
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/BadRequestError'
         "401":
           #description: |
           #  Access token is missing or invalid.
@@ -170,7 +170,7 @@ paths:
           #  - 01011001E: Invalid token format
           #  - 01011002E: Expired token
           #  - 01011003F: Invalid signature
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/UnauthorizedError'
         "403":
           #description: |
           #  Forbidden.
@@ -178,14 +178,14 @@ paths:
           #  Possible error codes:
           #  - 01011004E: Insufficient permissions
           #  - 01011005E: Invalid scope
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/ForbiddenError'
         "406":
           #description: |
           #  Not acceptable. Did you require application/json?
 
           #  Possible error codes:
           #  - 01021010E: Unsupported accept header
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/NotAcceptableError'
         "429":
           #description: |
           #  Too many requests.
@@ -193,7 +193,7 @@ paths:
           #  Possible error codes:
           #  - 01051000E: Rate limit exceeded
           #  - 01051001E: Quota exceeded
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/TooManyRequestsError'
         "500":
           #description: |
           # Server error.
@@ -201,7 +201,7 @@ paths:
           #  Possible error codes:
           #  - 01091000F: Internal server error
           #  - 01091001F: Database error
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/InternalServerError'
         default:
           #description: Unexpected error.
           $ref: '#/components/responses/Error'
@@ -232,7 +232,7 @@ paths:
           #    Possible error codes:
           #    - 01021007E: Invalid activation ID format
           #    - 01021009E: Required header missing
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/BadRequestError'
         "401":
           #description: |
           #  Access token is missing or invalid.
@@ -241,7 +241,7 @@ paths:
           #  - 01011000E: Missing authentication token
           #  - 01011001E: Invalid token format
           #  - 01011002E: Expired token
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/UnauthorizedError'
         "403":
           #description: |
           #  Forbidden.
@@ -249,7 +249,7 @@ paths:
           #  Possible error codes:
           #  - 01011004E: Insufficient permissions
           #  - 01011005E: Invalid scope
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/ForbiddenError'
         "404":
           #description: |
           #  Not found.
@@ -257,28 +257,28 @@ paths:
           #  Possible error codes:
           #  - 01041000E: Activation not found
           #  - 01041001E: Activation not visible to non-admin
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/NotFoundError'
         "406":
           #description: |
           #  Not acceptable. Did you require application/json?
 
           #  Possible error codes:
           #  - 01021010E: Unsupported accept header
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/NotAcceptableError'
         "429":
           #description: |
           #  Too many requests.
 
           #  Possible error codes:
           #  - 01051000E: Rate limit exceeded
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/TooManyRequestsError'
         "500":
           #description: |
           #  Server error.
 
           #  Possible error codes:
           #  - 01091000F: Internal server error
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/InternalServerError'
         default:
           #description: Unexpected error.
           $ref: '#/components/responses/Error'
@@ -311,7 +311,7 @@ paths:
           #  Possible error codes:
           #  - 01021007E: Invalid activation ID format
           #  - 01021009E: Required header missing
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/BadRequestError'
         "401":
           #description: |
           #  Access token is missing or invalid
@@ -320,7 +320,7 @@ paths:
           #  - 01011000E: Missing authentication token
           #  - 01011001E: Invalid token format
           #  - 01011002E: Expired token
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/UnauthorizedError'
         "403":
           #description: |
           #  Forbidden
@@ -328,7 +328,7 @@ paths:
           #  Possible error codes:
           #  - 01011004E: Insufficient permissions
           #  - 01011006E: Invalid scope
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/ForbiddenError'
         "404":
           #description: |
           #  Not found
@@ -336,28 +336,28 @@ paths:
           #  Possible error codes:
           #  - 01041000E: Activation not found
           #  - 01041001E: Activation not visible to non-admin
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/NotFoundError'
         "406":
           #description: |
           #  Not acceptable. Did you require application/json?
 
           #  Possible error codes:
           #  - 01021010E: Unsupported accept header
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/NotAcceptableError'
         "429":
           #description: |
           #  Too many requests
 
           #  Possible error codes:
           #  - 01051000E: Rate limit exceeded
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/TooManyRequestsError'
         "500":
           #description: |
           #  Server error
 
           #  Possible error codes:
           #  - 01091000F: Internal server error
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/InternalServerError'
         default:
           #description: Unexpected error
           $ref: '#/components/responses/Error'
@@ -390,7 +390,7 @@ paths:
           #  - 01021007E: Invalid activation ID format
           #  - 01021003E: Invalid RTP Service Provider ID format
           #  - 01021009E: Required header missing
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/BadRequestError'
         "401":
           #description: |
           #  Wrong credentials
@@ -399,7 +399,7 @@ paths:
           #  - 01011000E: Missing authentication token
           #  - 01011001E: Invalid token format
           #  - 01011002E: Expired token
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/UnauthorizedError'
         "403":
           #description: |
           #  Forbidden
@@ -407,21 +407,21 @@ paths:
           #  Possible error codes:
           #  - 01011004E: Insufficient permissions
           #  - 01011006E: Invalid scope
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/ForbiddenError'
         "404":
           #description: |
           #  Not found
 
           #  Possible error codes:
           #  - 01041000E: Activation not found
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/NotFoundError'
         "406":
           #description: |
           #  Not acceptable. Did you require application/json?
 
           #  Possible error codes:
           #  - 01021010E: Unsupported accept header
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/NotAcceptableError'
         "415":
           #description: |
           #  Unsupported media type. Did you provide application/json?
@@ -429,21 +429,21 @@ paths:
           #  Possible error codes:
           #  - 01021011E: Unsupported content type
           #  - 01021012E: Invalid content encoding
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/UnsupportedMediaTypeError'
         "429":
           #description: |
           #  Too many requests
 
           #  Possible error codes:
           #  - 01051000E: Rate limit exceeded
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/TooManyRequestsError'
         "500":
           #description: |
           #  Server error
 
           #  Possible error codes:
           #  - 01091000F: Internal server error
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/InternalServerError'
         default:
           #description: Unexpected error
           $ref: '#/components/responses/Error'
@@ -478,7 +478,7 @@ paths:
           #  - 01021008F: Missing Payer ID
           #  - 01021013F: Invalid Payer ID format
           #  - 01021009F: Required header missing
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/BadRequestError'
         "401":
           #description: |
           #  Access token is missing or invalid.
@@ -487,7 +487,7 @@ paths:
           #  - 01011000F: Missing authentication token
           #  - 01011001F: Invalid token format
           #  - 01011002F: Expired token
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/UnauthorizedError'
         "403":
           #description: |
           #  Forbidden.
@@ -495,32 +495,32 @@ paths:
           #  Possible error codes:
           #  - 01011004F: Insufficient permissions
           #  - 01011005F: Invalid scope
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/ForbiddenError'
+        "404":
+          #description: |
+          #  Not found.
+          $ref: '#/components/responses/NotFoundError'
         "406":
           #description: |
           #  Not acceptable. Did you require application/json?
 
           #  Possible error codes:
           #  - 01021010F: Unsupported accept header
-          $ref: '#/components/responses/Error'
-        "404":
-          #description: |
-          #  Not found.
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/NotAcceptableError'
         "429":
           #description: |
           #  Too many requests.
 
           #  Possible error codes:
           #  - 01051000F: Rate limit exceeded
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/TooManyRequestsError'
         "500":
           #description: |
           #  Server error.
 
           #  Possible error codes:
           #  - 01091000F: Internal server error
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/InternalServerError'
         default:
           #description: Unexpected error.
           $ref: '#/components/responses/Error'
@@ -1132,7 +1132,7 @@ components:
             $ref: '#/components/schemas/ActivationLocation'
 
     ConflictError:
-      description: Response returned when a RTP payer is already active.
+      description: Conflict. An activation for this Payer already exists. The Location header points to the existing resource.
       headers:
         Access-Control-Allow-Origin:
           description: |
@@ -1162,7 +1162,7 @@ components:
             $ref: '#/components/schemas/Errors'
 
     Error:
-      description: Response returned when an error occured.
+      description: Response returned when an unexpected error occurred.
       headers:
         Access-Control-Allow-Origin:
           description: |
@@ -1178,6 +1178,294 @@ components:
             $ref: '#/components/schemas/RateLimitLimit'
         RateLimit-Reset:
           description: The number of seconds left in the current period
+          required: false
+          schema:
+            $ref: '#/components/schemas/RateLimitReset'
+        Retry-After:
+          description: |
+            The number of seconds to wait before allowing a follow-up request.
+          required: false
+          schema:
+            $ref: '#/components/schemas/RetryAfter'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Errors'
+        text/*:
+          schema:
+            type: string
+            pattern: "^[ -~]{0,65535}$"
+            maxLength: 65535
+
+    BadRequestError:
+      description: Bad request. The request was malformed or contained invalid parameters.
+      headers:
+        Access-Control-Allow-Origin:
+          description: |
+            Indicates whether the response can be shared with requesting code
+            from the given origin.
+          required: false
+          schema:
+            $ref: '#/components/schemas/AccessControlAllowOrigin'
+        RateLimit-Limit:
+          description: The number of allowed requests in the current period.
+          required: false
+          schema:
+            $ref: '#/components/schemas/RateLimitLimit'
+        RateLimit-Reset:
+          description: The number of seconds left in the current period.
+          required: false
+          schema:
+            $ref: '#/components/schemas/RateLimitReset'
+        Retry-After:
+          description: |
+            The number of seconds to wait before allowing a follow-up request.
+          required: false
+          schema:
+            $ref: '#/components/schemas/RetryAfter'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Errors'
+        text/*:
+          schema:
+            type: string
+            pattern: "^[ -~]{0,65535}$"
+            maxLength: 65535
+
+    UnauthorizedError:
+      description: Unauthorized. Access token is missing or invalid.
+      headers:
+        Access-Control-Allow-Origin:
+          description: |
+            Indicates whether the response can be shared with requesting code
+            from the given origin.
+          required: false
+          schema:
+            $ref: '#/components/schemas/AccessControlAllowOrigin'
+        RateLimit-Limit:
+          description: The number of allowed requests in the current period.
+          required: false
+          schema:
+            $ref: '#/components/schemas/RateLimitLimit'
+        RateLimit-Reset:
+          description: The number of seconds left in the current period.
+          required: false
+          schema:
+            $ref: '#/components/schemas/RateLimitReset'
+        Retry-After:
+          description: |
+            The number of seconds to wait before allowing a follow-up request.
+          required: false
+          schema:
+            $ref: '#/components/schemas/RetryAfter'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Errors'
+        text/*:
+          schema:
+            type: string
+            pattern: "^[ -~]{0,65535}$"
+            maxLength: 65535
+
+    ForbiddenError:
+      description: Forbidden. The caller has insufficient permissions or the provided identity does not match the token subject.
+      headers:
+        Access-Control-Allow-Origin:
+          description: |
+            Indicates whether the response can be shared with requesting code
+            from the given origin.
+          required: false
+          schema:
+            $ref: '#/components/schemas/AccessControlAllowOrigin'
+        RateLimit-Limit:
+          description: The number of allowed requests in the current period.
+          required: false
+          schema:
+            $ref: '#/components/schemas/RateLimitLimit'
+        RateLimit-Reset:
+          description: The number of seconds left in the current period.
+          required: false
+          schema:
+            $ref: '#/components/schemas/RateLimitReset'
+        Retry-After:
+          description: |
+            The number of seconds to wait before allowing a follow-up request.
+          required: false
+          schema:
+            $ref: '#/components/schemas/RetryAfter'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Errors'
+        text/*:
+          schema:
+            type: string
+            pattern: "^[ -~]{0,65535}$"
+            maxLength: 65535
+
+    NotFoundError:
+      description: Not found. The requested activation does not exist or is not visible to the caller.
+      headers:
+        Access-Control-Allow-Origin:
+          description: |
+            Indicates whether the response can be shared with requesting code
+            from the given origin.
+          required: false
+          schema:
+            $ref: '#/components/schemas/AccessControlAllowOrigin'
+        RateLimit-Limit:
+          description: The number of allowed requests in the current period.
+          required: false
+          schema:
+            $ref: '#/components/schemas/RateLimitLimit'
+        RateLimit-Reset:
+          description: The number of seconds left in the current period.
+          required: false
+          schema:
+            $ref: '#/components/schemas/RateLimitReset'
+        Retry-After:
+          description: |
+            The number of seconds to wait before allowing a follow-up request.
+          required: false
+          schema:
+            $ref: '#/components/schemas/RetryAfter'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Errors'
+        text/*:
+          schema:
+            type: string
+            pattern: "^[ -~]{0,65535}$"
+            maxLength: 65535
+
+    NotAcceptableError:
+      description: Not acceptable. The Accept header specifies a media type not supported by this API.
+      headers:
+        Access-Control-Allow-Origin:
+          description: |
+            Indicates whether the response can be shared with requesting code
+            from the given origin.
+          required: false
+          schema:
+            $ref: '#/components/schemas/AccessControlAllowOrigin'
+        RateLimit-Limit:
+          description: The number of allowed requests in the current period.
+          required: false
+          schema:
+            $ref: '#/components/schemas/RateLimitLimit'
+        RateLimit-Reset:
+          description: The number of seconds left in the current period.
+          required: false
+          schema:
+            $ref: '#/components/schemas/RateLimitReset'
+        Retry-After:
+          description: |
+            The number of seconds to wait before allowing a follow-up request.
+          required: false
+          schema:
+            $ref: '#/components/schemas/RetryAfter'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Errors'
+        text/*:
+          schema:
+            type: string
+            pattern: "^[ -~]{0,65535}$"
+            maxLength: 65535
+
+    UnsupportedMediaTypeError:
+      description: Unsupported media type. The Content-Type header specifies a format not supported by this API.
+      headers:
+        Access-Control-Allow-Origin:
+          description: |
+            Indicates whether the response can be shared with requesting code
+            from the given origin.
+          required: false
+          schema:
+            $ref: '#/components/schemas/AccessControlAllowOrigin'
+        RateLimit-Limit:
+          description: The number of allowed requests in the current period.
+          required: false
+          schema:
+            $ref: '#/components/schemas/RateLimitLimit'
+        RateLimit-Reset:
+          description: The number of seconds left in the current period.
+          required: false
+          schema:
+            $ref: '#/components/schemas/RateLimitReset'
+        Retry-After:
+          description: |
+            The number of seconds to wait before allowing a follow-up request.
+          required: false
+          schema:
+            $ref: '#/components/schemas/RetryAfter'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Errors'
+        text/*:
+          schema:
+            type: string
+            pattern: "^[ -~]{0,65535}$"
+            maxLength: 65535
+
+    TooManyRequestsError:
+      description: Too many requests. The client has exceeded the rate limit or quota.
+      headers:
+        Access-Control-Allow-Origin:
+          description: |
+            Indicates whether the response can be shared with requesting code
+            from the given origin.
+          required: false
+          schema:
+            $ref: '#/components/schemas/AccessControlAllowOrigin'
+        RateLimit-Limit:
+          description: The number of allowed requests in the current period.
+          required: false
+          schema:
+            $ref: '#/components/schemas/RateLimitLimit'
+        RateLimit-Reset:
+          description: The number of seconds left in the current period.
+          required: false
+          schema:
+            $ref: '#/components/schemas/RateLimitReset'
+        Retry-After:
+          description: |
+            The number of seconds to wait before allowing a follow-up request.
+          required: false
+          schema:
+            $ref: '#/components/schemas/RetryAfter'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Errors'
+        text/*:
+          schema:
+            type: string
+            pattern: "^[ -~]{0,65535}$"
+            maxLength: 65535
+
+    InternalServerError:
+      description: Internal server error. An unexpected error occurred on the server side.
+      headers:
+        Access-Control-Allow-Origin:
+          description: |
+            Indicates whether the response can be shared with requesting code
+            from the given origin.
+          required: false
+          schema:
+            $ref: '#/components/schemas/AccessControlAllowOrigin'
+        RateLimit-Limit:
+          description: The number of allowed requests in the current period.
+          required: false
+          schema:
+            $ref: '#/components/schemas/RateLimitLimit'
+        RateLimit-Reset:
+          description: The number of seconds left in the current period.
           required: false
           schema:
             $ref: '#/components/schemas/RateLimitReset'

--- a/src/srtp/api/pagopa/payees_registry.yaml
+++ b/src/srtp/api/pagopa/payees_registry.yaml
@@ -45,22 +45,19 @@ paths:
           $ref: '#/components/responses/PageOfPayees'
         "400":
           # description: Bad Request. The request was malformed, for example due to invalid pagination parameters.
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/BadRequestError'
         "401":
           # description: Unauthorized. The access token is missing, expired, or invalid.
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/UnauthorizedError'
         "403":
           # description: Forbidden. The client is authenticated but does not have the required permissions to access this resource.
-          $ref: '#/components/responses/Error'
-        "406":
-          # description: Not Acceptable. The server cannot produce a response matching the `Accept` header. Ensure you accept `application/json`.
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/ForbiddenError'
         "429":
           # description: Too Many Requests. The client has exceeded the rate limit.
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/TooManyRequestsError'
         "500":
           # description: Internal Server Error. An unexpected error occurred on the server.
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/InternalServerError'
         default:
           # description: Unexpected Error. An error occurred that is not covered by other status codes.
           $ref: '#/components/responses/Error'
@@ -434,6 +431,181 @@ components:
   responses:
     Error:
       description: A generic error response returned by the API.
+      headers:
+        Access-Control-Allow-Origin:
+          description: |
+            Indicates whether the response can be shared with requesting code from the given origin.
+          required: false
+          schema:
+            $ref: '#/components/schemas/AccessControlAllowOrigin'
+        RateLimit-Limit:
+          description: The number of allowed requests in the current period.
+          required: false
+          schema:
+            $ref: '#/components/schemas/RateLimitLimit'
+        RateLimit-Reset:
+          description: The number of seconds left in the current period
+          required: false
+          schema:
+            $ref: '#/components/schemas/RateLimitReset'
+        Retry-After:
+          description: |
+            The number of seconds to wait before allowing a follow-up request.
+          required: false
+          schema:
+            $ref: '#/components/schemas/RetryAfter'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Errors'
+        text/*:
+          schema:
+            type: string
+            pattern: "^[ -~]{0,65535}$"
+            maxLength: 65535
+
+    BadRequestError:
+      description: Bad request. The request was malformed or contained invalid parameters (e.g. invalid pagination values).
+      headers:
+        Access-Control-Allow-Origin:
+          description: |
+            Indicates whether the response can be shared with requesting code from the given origin.
+          required: false
+          schema:
+            $ref: '#/components/schemas/AccessControlAllowOrigin'
+        RateLimit-Limit:
+          description: The number of allowed requests in the current period.
+          required: false
+          schema:
+            $ref: '#/components/schemas/RateLimitLimit'
+        RateLimit-Reset:
+          description: The number of seconds left in the current period
+          required: false
+          schema:
+            $ref: '#/components/schemas/RateLimitReset'
+        Retry-After:
+          description: |
+            The number of seconds to wait before allowing a follow-up request.
+          required: false
+          schema:
+            $ref: '#/components/schemas/RetryAfter'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Errors'
+        text/*:
+          schema:
+            type: string
+            pattern: "^[ -~]{0,65535}$"
+            maxLength: 65535
+
+    UnauthorizedError:
+      description: Unauthorized. The access token is missing, expired, or invalid.
+      headers:
+        Access-Control-Allow-Origin:
+          description: |
+            Indicates whether the response can be shared with requesting code from the given origin.
+          required: false
+          schema:
+            $ref: '#/components/schemas/AccessControlAllowOrigin'
+        RateLimit-Limit:
+          description: The number of allowed requests in the current period.
+          required: false
+          schema:
+            $ref: '#/components/schemas/RateLimitLimit'
+        RateLimit-Reset:
+          description: The number of seconds left in the current period
+          required: false
+          schema:
+            $ref: '#/components/schemas/RateLimitReset'
+        Retry-After:
+          description: |
+            The number of seconds to wait before allowing a follow-up request.
+          required: false
+          schema:
+            $ref: '#/components/schemas/RetryAfter'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Errors'
+        text/*:
+          schema:
+            type: string
+            pattern: "^[ -~]{0,65535}$"
+            maxLength: 65535
+
+    ForbiddenError:
+      description: Forbidden. The client is authenticated but does not have the required permissions to access this resource.
+      headers:
+        Access-Control-Allow-Origin:
+          description: |
+            Indicates whether the response can be shared with requesting code from the given origin.
+          required: false
+          schema:
+            $ref: '#/components/schemas/AccessControlAllowOrigin'
+        RateLimit-Limit:
+          description: The number of allowed requests in the current period.
+          required: false
+          schema:
+            $ref: '#/components/schemas/RateLimitLimit'
+        RateLimit-Reset:
+          description: The number of seconds left in the current period
+          required: false
+          schema:
+            $ref: '#/components/schemas/RateLimitReset'
+        Retry-After:
+          description: |
+            The number of seconds to wait before allowing a follow-up request.
+          required: false
+          schema:
+            $ref: '#/components/schemas/RetryAfter'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Errors'
+        text/*:
+          schema:
+            type: string
+            pattern: "^[ -~]{0,65535}$"
+            maxLength: 65535
+
+    TooManyRequestsError:
+      description: Too many requests. The client has exceeded the rate limit or quota.
+      headers:
+        Access-Control-Allow-Origin:
+          description: |
+            Indicates whether the response can be shared with requesting code from the given origin.
+          required: false
+          schema:
+            $ref: '#/components/schemas/AccessControlAllowOrigin'
+        RateLimit-Limit:
+          description: The number of allowed requests in the current period.
+          required: false
+          schema:
+            $ref: '#/components/schemas/RateLimitLimit'
+        RateLimit-Reset:
+          description: The number of seconds left in the current period
+          required: false
+          schema:
+            $ref: '#/components/schemas/RateLimitReset'
+        Retry-After:
+          description: |
+            The number of seconds to wait before allowing a follow-up request.
+          required: false
+          schema:
+            $ref: '#/components/schemas/RetryAfter'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Errors'
+        text/*:
+          schema:
+            type: string
+            pattern: "^[ -~]{0,65535}$"
+            maxLength: 65535
+
+    InternalServerError:
+      description: Internal server error. An unexpected error occurred on the server side.
       headers:
         Access-Control-Allow-Origin:
           description: |

--- a/src/srtp/api/pagopa/payees_registry.yaml
+++ b/src/srtp/api/pagopa/payees_registry.yaml
@@ -433,27 +433,13 @@ components:
       description: A generic error response returned by the API.
       headers:
         Access-Control-Allow-Origin:
-          description: |
-            Indicates whether the response can be shared with requesting code from the given origin.
-          required: false
-          schema:
-            $ref: '#/components/schemas/AccessControlAllowOrigin'
+          $ref: '#/components/headers/AccessControlAllowOrigin'
         RateLimit-Limit:
-          description: The number of allowed requests in the current period.
-          required: false
-          schema:
-            $ref: '#/components/schemas/RateLimitLimit'
+          $ref: '#/components/headers/RateLimitLimit'
         RateLimit-Reset:
-          description: The number of seconds left in the current period
-          required: false
-          schema:
-            $ref: '#/components/schemas/RateLimitReset'
+          $ref: '#/components/headers/RateLimitReset'
         Retry-After:
-          description: |
-            The number of seconds to wait before allowing a follow-up request.
-          required: false
-          schema:
-            $ref: '#/components/schemas/RetryAfter'
+          $ref: '#/components/headers/RetryAfter'
       content:
         application/json:
           schema:
@@ -468,27 +454,13 @@ components:
       description: Bad request. The request was malformed or contained invalid parameters (e.g. invalid pagination values).
       headers:
         Access-Control-Allow-Origin:
-          description: |
-            Indicates whether the response can be shared with requesting code from the given origin.
-          required: false
-          schema:
-            $ref: '#/components/schemas/AccessControlAllowOrigin'
+          $ref: '#/components/headers/AccessControlAllowOrigin'
         RateLimit-Limit:
-          description: The number of allowed requests in the current period.
-          required: false
-          schema:
-            $ref: '#/components/schemas/RateLimitLimit'
+          $ref: '#/components/headers/RateLimitLimit'
         RateLimit-Reset:
-          description: The number of seconds left in the current period
-          required: false
-          schema:
-            $ref: '#/components/schemas/RateLimitReset'
+          $ref: '#/components/headers/RateLimitReset'
         Retry-After:
-          description: |
-            The number of seconds to wait before allowing a follow-up request.
-          required: false
-          schema:
-            $ref: '#/components/schemas/RetryAfter'
+          $ref: '#/components/headers/RetryAfter'
       content:
         application/json:
           schema:
@@ -503,27 +475,13 @@ components:
       description: Unauthorized. The access token is missing, expired, or invalid.
       headers:
         Access-Control-Allow-Origin:
-          description: |
-            Indicates whether the response can be shared with requesting code from the given origin.
-          required: false
-          schema:
-            $ref: '#/components/schemas/AccessControlAllowOrigin'
+          $ref: '#/components/headers/AccessControlAllowOrigin'
         RateLimit-Limit:
-          description: The number of allowed requests in the current period.
-          required: false
-          schema:
-            $ref: '#/components/schemas/RateLimitLimit'
+          $ref: '#/components/headers/RateLimitLimit'
         RateLimit-Reset:
-          description: The number of seconds left in the current period
-          required: false
-          schema:
-            $ref: '#/components/schemas/RateLimitReset'
+          $ref: '#/components/headers/RateLimitReset'
         Retry-After:
-          description: |
-            The number of seconds to wait before allowing a follow-up request.
-          required: false
-          schema:
-            $ref: '#/components/schemas/RetryAfter'
+          $ref: '#/components/headers/RetryAfter'
       content:
         application/json:
           schema:
@@ -538,27 +496,13 @@ components:
       description: Forbidden. The client is authenticated but does not have the required permissions to access this resource.
       headers:
         Access-Control-Allow-Origin:
-          description: |
-            Indicates whether the response can be shared with requesting code from the given origin.
-          required: false
-          schema:
-            $ref: '#/components/schemas/AccessControlAllowOrigin'
+          $ref: '#/components/headers/AccessControlAllowOrigin'
         RateLimit-Limit:
-          description: The number of allowed requests in the current period.
-          required: false
-          schema:
-            $ref: '#/components/schemas/RateLimitLimit'
+          $ref: '#/components/headers/RateLimitLimit'
         RateLimit-Reset:
-          description: The number of seconds left in the current period
-          required: false
-          schema:
-            $ref: '#/components/schemas/RateLimitReset'
+          $ref: '#/components/headers/RateLimitReset'
         Retry-After:
-          description: |
-            The number of seconds to wait before allowing a follow-up request.
-          required: false
-          schema:
-            $ref: '#/components/schemas/RetryAfter'
+          $ref: '#/components/headers/RetryAfter'
       content:
         application/json:
           schema:
@@ -573,27 +517,13 @@ components:
       description: Too many requests. The client has exceeded the rate limit or quota.
       headers:
         Access-Control-Allow-Origin:
-          description: |
-            Indicates whether the response can be shared with requesting code from the given origin.
-          required: false
-          schema:
-            $ref: '#/components/schemas/AccessControlAllowOrigin'
+          $ref: '#/components/headers/AccessControlAllowOrigin'
         RateLimit-Limit:
-          description: The number of allowed requests in the current period.
-          required: false
-          schema:
-            $ref: '#/components/schemas/RateLimitLimit'
+          $ref: '#/components/headers/RateLimitLimit'
         RateLimit-Reset:
-          description: The number of seconds left in the current period
-          required: false
-          schema:
-            $ref: '#/components/schemas/RateLimitReset'
+          $ref: '#/components/headers/RateLimitReset'
         Retry-After:
-          description: |
-            The number of seconds to wait before allowing a follow-up request.
-          required: false
-          schema:
-            $ref: '#/components/schemas/RetryAfter'
+          $ref: '#/components/headers/RetryAfter'
       content:
         application/json:
           schema:
@@ -608,27 +538,13 @@ components:
       description: Internal server error. An unexpected error occurred on the server side.
       headers:
         Access-Control-Allow-Origin:
-          description: |
-            Indicates whether the response can be shared with requesting code from the given origin.
-          required: false
-          schema:
-            $ref: '#/components/schemas/AccessControlAllowOrigin'
+          $ref: '#/components/headers/AccessControlAllowOrigin'
         RateLimit-Limit:
-          description: The number of allowed requests in the current period.
-          required: false
-          schema:
-            $ref: '#/components/schemas/RateLimitLimit'
+          $ref: '#/components/headers/RateLimitLimit'
         RateLimit-Reset:
-          description: The number of seconds left in the current period
-          required: false
-          schema:
-            $ref: '#/components/schemas/RateLimitReset'
+          $ref: '#/components/headers/RateLimitReset'
         Retry-After:
-          description: |
-            The number of seconds to wait before allowing a follow-up request.
-          required: false
-          schema:
-            $ref: '#/components/schemas/RetryAfter'
+          $ref: '#/components/headers/RetryAfter'
       content:
         application/json:
           schema:
@@ -643,26 +559,43 @@ components:
       description: Response to the request to get Payees.
       headers:
         Access-Control-Allow-Origin:
-          description: |
-            Indicates whether the response can be shared with requesting code
-            from the given origin.
-          required: false
-          schema:
-            $ref: '#/components/schemas/AccessControlAllowOrigin'
+          $ref: '#/components/headers/AccessControlAllowOrigin'
         RateLimit-Limit:
-          description: The number of allowed requests in the current period.
-          required: false
-          schema:
-            $ref: '#/components/schemas/RateLimitLimit'
+          $ref: '#/components/headers/RateLimitLimit'
         RateLimit-Reset:
-          description: The number of seconds left in the current period.
-          required: false
-          schema:
-            $ref: '#/components/schemas/RateLimitReset'
+          $ref: '#/components/headers/RateLimitReset'
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/PageOfPayees'
+
+  # ============================================================================
+  # Headers.
+  # ============================================================================
+  headers:
+    AccessControlAllowOrigin:
+      description: |
+        Indicates whether the response can be shared with requesting code
+        from the given origin.
+      required: false
+      schema:
+        $ref: '#/components/schemas/AccessControlAllowOrigin'
+    RateLimitLimit:
+      description: The number of allowed requests in the current period.
+      required: false
+      schema:
+        $ref: '#/components/schemas/RateLimitLimit'
+    RateLimitReset:
+      description: The number of seconds left in the current period.
+      required: false
+      schema:
+        $ref: '#/components/schemas/RateLimitReset'
+    RetryAfter:
+      description: |
+        The number of seconds to wait before allowing a follow-up request.
+      required: false
+      schema:
+        $ref: '#/components/schemas/RetryAfter'
 
   # ============================================================================
   # Security schemes.

--- a/src/srtp/api/pagopa/service_providers_registry.yaml
+++ b/src/srtp/api/pagopa/service_providers_registry.yaml
@@ -455,28 +455,13 @@ components:
       description: A generic error response body used for all client and server errors.
       headers:
         Access-Control-Allow-Origin:
-          description: |
-            Indicates whether the response can be shared with requesting code
-            from the given origin.
-          required: false
-          schema:
-            $ref: "#/components/schemas/AccessControlAllowOrigin"
+          $ref: "#/components/headers/AccessControlAllowOrigin"
         RateLimit-Limit:
-          description: The number of allowed requests in the current period.
-          required: false
-          schema:
-            $ref: "#/components/schemas/RateLimitLimit"
+          $ref: "#/components/headers/RateLimitLimit"
         RateLimit-Reset:
-          description: The number of seconds left in the current period
-          required: false
-          schema:
-            $ref: "#/components/schemas/RateLimitReset"
+          $ref: "#/components/headers/RateLimitReset"
         Retry-After:
-          description: |
-            The number of seconds to wait before allowing a follow-up request.
-          required: false
-          schema:
-            $ref: "#/components/schemas/RetryAfter"
+          $ref: "#/components/headers/RetryAfter"
       content:
         application/json:
           schema:
@@ -492,28 +477,13 @@ components:
       description: Bad request. The request was malformed or contained invalid parameters, such as a poorly formatted RequestId header.
       headers:
         Access-Control-Allow-Origin:
-          description: |
-            Indicates whether the response can be shared with requesting code
-            from the given origin.
-          required: false
-          schema:
-            $ref: "#/components/schemas/AccessControlAllowOrigin"
+          $ref: "#/components/headers/AccessControlAllowOrigin"
         RateLimit-Limit:
-          description: The number of allowed requests in the current period.
-          required: false
-          schema:
-            $ref: "#/components/schemas/RateLimitLimit"
+          $ref: "#/components/headers/RateLimitLimit"
         RateLimit-Reset:
-          description: The number of seconds left in the current period
-          required: false
-          schema:
-            $ref: "#/components/schemas/RateLimitReset"
+          $ref: "#/components/headers/RateLimitReset"
         Retry-After:
-          description: |
-            The number of seconds to wait before allowing a follow-up request.
-          required: false
-          schema:
-            $ref: "#/components/schemas/RetryAfter"
+          $ref: "#/components/headers/RetryAfter"
       content:
         application/json:
           schema:
@@ -529,28 +499,13 @@ components:
       description: Unauthorized. The access token is missing, expired, or invalid.
       headers:
         Access-Control-Allow-Origin:
-          description: |
-            Indicates whether the response can be shared with requesting code
-            from the given origin.
-          required: false
-          schema:
-            $ref: "#/components/schemas/AccessControlAllowOrigin"
+          $ref: "#/components/headers/AccessControlAllowOrigin"
         RateLimit-Limit:
-          description: The number of allowed requests in the current period.
-          required: false
-          schema:
-            $ref: "#/components/schemas/RateLimitLimit"
+          $ref: "#/components/headers/RateLimitLimit"
         RateLimit-Reset:
-          description: The number of seconds left in the current period
-          required: false
-          schema:
-            $ref: "#/components/schemas/RateLimitReset"
+          $ref: "#/components/headers/RateLimitReset"
         Retry-After:
-          description: |
-            The number of seconds to wait before allowing a follow-up request.
-          required: false
-          schema:
-            $ref: "#/components/schemas/RetryAfter"
+          $ref: "#/components/headers/RetryAfter"
       content:
         application/json:
           schema:
@@ -566,28 +521,13 @@ components:
       description: Forbidden. The client is authenticated but does not have the required permissions to access this resource.
       headers:
         Access-Control-Allow-Origin:
-          description: |
-            Indicates whether the response can be shared with requesting code
-            from the given origin.
-          required: false
-          schema:
-            $ref: "#/components/schemas/AccessControlAllowOrigin"
+          $ref: "#/components/headers/AccessControlAllowOrigin"
         RateLimit-Limit:
-          description: The number of allowed requests in the current period.
-          required: false
-          schema:
-            $ref: "#/components/schemas/RateLimitLimit"
+          $ref: "#/components/headers/RateLimitLimit"
         RateLimit-Reset:
-          description: The number of seconds left in the current period
-          required: false
-          schema:
-            $ref: "#/components/schemas/RateLimitReset"
+          $ref: "#/components/headers/RateLimitReset"
         Retry-After:
-          description: |
-            The number of seconds to wait before allowing a follow-up request.
-          required: false
-          schema:
-            $ref: "#/components/schemas/RetryAfter"
+          $ref: "#/components/headers/RetryAfter"
       content:
         application/json:
           schema:
@@ -603,28 +543,13 @@ components:
       description: Too many requests. The client has exceeded the rate limit or quota.
       headers:
         Access-Control-Allow-Origin:
-          description: |
-            Indicates whether the response can be shared with requesting code
-            from the given origin.
-          required: false
-          schema:
-            $ref: "#/components/schemas/AccessControlAllowOrigin"
+          $ref: "#/components/headers/AccessControlAllowOrigin"
         RateLimit-Limit:
-          description: The number of allowed requests in the current period.
-          required: false
-          schema:
-            $ref: "#/components/schemas/RateLimitLimit"
+          $ref: "#/components/headers/RateLimitLimit"
         RateLimit-Reset:
-          description: The number of seconds left in the current period
-          required: false
-          schema:
-            $ref: "#/components/schemas/RateLimitReset"
+          $ref: "#/components/headers/RateLimitReset"
         Retry-After:
-          description: |
-            The number of seconds to wait before allowing a follow-up request.
-          required: false
-          schema:
-            $ref: "#/components/schemas/RetryAfter"
+          $ref: "#/components/headers/RetryAfter"
       content:
         application/json:
           schema:
@@ -640,28 +565,13 @@ components:
       description: Internal server error. An unexpected error occurred on the server side.
       headers:
         Access-Control-Allow-Origin:
-          description: |
-            Indicates whether the response can be shared with requesting code
-            from the given origin.
-          required: false
-          schema:
-            $ref: "#/components/schemas/AccessControlAllowOrigin"
+          $ref: "#/components/headers/AccessControlAllowOrigin"
         RateLimit-Limit:
-          description: The number of allowed requests in the current period.
-          required: false
-          schema:
-            $ref: "#/components/schemas/RateLimitLimit"
+          $ref: "#/components/headers/RateLimitLimit"
         RateLimit-Reset:
-          description: The number of seconds left in the current period
-          required: false
-          schema:
-            $ref: "#/components/schemas/RateLimitReset"
+          $ref: "#/components/headers/RateLimitReset"
         Retry-After:
-          description: |
-            The number of seconds to wait before allowing a follow-up request.
-          required: false
-          schema:
-            $ref: "#/components/schemas/RetryAfter"
+          $ref: "#/components/headers/RetryAfter"
       content:
         application/json:
           schema:
@@ -677,26 +587,43 @@ components:
       description: A successful response containing the full list of TSPs and SPs.
       headers:
         Access-Control-Allow-Origin:
-          description: |
-            Indicates whether the response can be shared with requesting code
-            from the given origin.
-          required: false
-          schema:
-            $ref: "#/components/schemas/AccessControlAllowOrigin"
+          $ref: "#/components/headers/AccessControlAllowOrigin"
         RateLimit-Limit:
-          description: The number of allowed requests in the current period.
-          required: false
-          schema:
-            $ref: "#/components/schemas/RateLimitLimit"
+          $ref: "#/components/headers/RateLimitLimit"
         RateLimit-Reset:
-          description: The number of seconds left in the current period.
-          required: false
-          schema:
-            $ref: "#/components/schemas/RateLimitReset"
+          $ref: "#/components/headers/RateLimitReset"
       content:
         application/json:
           schema:
             $ref: "#/components/schemas/ServiceProviders"
+  # ============================================================================
+  # Headers.
+  # ============================================================================
+  headers:
+    AccessControlAllowOrigin:
+      description: |
+        Indicates whether the response can be shared with requesting code
+        from the given origin.
+      required: false
+      schema:
+        $ref: "#/components/schemas/AccessControlAllowOrigin"
+    RateLimitLimit:
+      description: The number of allowed requests in the current period.
+      required: false
+      schema:
+        $ref: "#/components/schemas/RateLimitLimit"
+    RateLimitReset:
+      description: The number of seconds left in the current period.
+      required: false
+      schema:
+        $ref: "#/components/schemas/RateLimitReset"
+    RetryAfter:
+      description: |
+        The number of seconds to wait before allowing a follow-up request.
+      required: false
+      schema:
+        $ref: "#/components/schemas/RetryAfter"
+
   # ============================================================================
   # Security schemes.
   # ============================================================================

--- a/src/srtp/api/pagopa/service_providers_registry.yaml
+++ b/src/srtp/api/pagopa/service_providers_registry.yaml
@@ -49,22 +49,19 @@ paths:
           $ref: "#/components/responses/ServiceProvidersResponse"
         "400":
           # description: Bad Request. The request was malformed or contained invalid parameters, such as a poorly formatted RequestId header.
-          $ref: "#/components/responses/Error"
+          $ref: "#/components/responses/BadRequestError"
         "401":
           # description: Unauthorized. The access token is missing, expired, or invalid.
-          $ref: "#/components/responses/Error"
+          $ref: "#/components/responses/UnauthorizedError"
         "403":
           # description: Forbidden. The client is authenticated but does not have permission to access this resource. Check the OAuth2 scopes.
-          $ref: "#/components/responses/Error"
-        "406":
-          # description: Not acceptable. The server cannot produce a response matching the list of acceptable values defined in the request's `Accept` header. Ensure `application/json` is accepted.
-          $ref: "#/components/responses/Error"
+          $ref: "#/components/responses/ForbiddenError"
         "429":
           # description: Too Many Requests. The client has sent too many requests in a given amount of time.
-          $ref: "#/components/responses/Error"
+          $ref: "#/components/responses/TooManyRequestsError"
         "500":
           # description: Internal Server Error. An unexpected error occurred on the server side.
-          $ref: "#/components/responses/Error"
+          $ref: "#/components/responses/InternalServerError"
         default:
           # description: Unexpected Error. An error occurred that does not fit any other specific status code.
           $ref: "#/components/responses/Error"
@@ -456,6 +453,191 @@ components:
   responses:
     Error:
       description: A generic error response body used for all client and server errors.
+      headers:
+        Access-Control-Allow-Origin:
+          description: |
+            Indicates whether the response can be shared with requesting code
+            from the given origin.
+          required: false
+          schema:
+            $ref: "#/components/schemas/AccessControlAllowOrigin"
+        RateLimit-Limit:
+          description: The number of allowed requests in the current period.
+          required: false
+          schema:
+            $ref: "#/components/schemas/RateLimitLimit"
+        RateLimit-Reset:
+          description: The number of seconds left in the current period
+          required: false
+          schema:
+            $ref: "#/components/schemas/RateLimitReset"
+        Retry-After:
+          description: |
+            The number of seconds to wait before allowing a follow-up request.
+          required: false
+          schema:
+            $ref: "#/components/schemas/RetryAfter"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Errors"
+        text/*:
+          schema:
+            type: string
+            pattern: "^[ -~]{0,65535}$"
+            minLength: 0
+            maxLength: 65535
+
+    BadRequestError:
+      description: Bad request. The request was malformed or contained invalid parameters, such as a poorly formatted RequestId header.
+      headers:
+        Access-Control-Allow-Origin:
+          description: |
+            Indicates whether the response can be shared with requesting code
+            from the given origin.
+          required: false
+          schema:
+            $ref: "#/components/schemas/AccessControlAllowOrigin"
+        RateLimit-Limit:
+          description: The number of allowed requests in the current period.
+          required: false
+          schema:
+            $ref: "#/components/schemas/RateLimitLimit"
+        RateLimit-Reset:
+          description: The number of seconds left in the current period
+          required: false
+          schema:
+            $ref: "#/components/schemas/RateLimitReset"
+        Retry-After:
+          description: |
+            The number of seconds to wait before allowing a follow-up request.
+          required: false
+          schema:
+            $ref: "#/components/schemas/RetryAfter"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Errors"
+        text/*:
+          schema:
+            type: string
+            pattern: "^[ -~]{0,65535}$"
+            minLength: 0
+            maxLength: 65535
+
+    UnauthorizedError:
+      description: Unauthorized. The access token is missing, expired, or invalid.
+      headers:
+        Access-Control-Allow-Origin:
+          description: |
+            Indicates whether the response can be shared with requesting code
+            from the given origin.
+          required: false
+          schema:
+            $ref: "#/components/schemas/AccessControlAllowOrigin"
+        RateLimit-Limit:
+          description: The number of allowed requests in the current period.
+          required: false
+          schema:
+            $ref: "#/components/schemas/RateLimitLimit"
+        RateLimit-Reset:
+          description: The number of seconds left in the current period
+          required: false
+          schema:
+            $ref: "#/components/schemas/RateLimitReset"
+        Retry-After:
+          description: |
+            The number of seconds to wait before allowing a follow-up request.
+          required: false
+          schema:
+            $ref: "#/components/schemas/RetryAfter"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Errors"
+        text/*:
+          schema:
+            type: string
+            pattern: "^[ -~]{0,65535}$"
+            minLength: 0
+            maxLength: 65535
+
+    ForbiddenError:
+      description: Forbidden. The client is authenticated but does not have the required permissions to access this resource.
+      headers:
+        Access-Control-Allow-Origin:
+          description: |
+            Indicates whether the response can be shared with requesting code
+            from the given origin.
+          required: false
+          schema:
+            $ref: "#/components/schemas/AccessControlAllowOrigin"
+        RateLimit-Limit:
+          description: The number of allowed requests in the current period.
+          required: false
+          schema:
+            $ref: "#/components/schemas/RateLimitLimit"
+        RateLimit-Reset:
+          description: The number of seconds left in the current period
+          required: false
+          schema:
+            $ref: "#/components/schemas/RateLimitReset"
+        Retry-After:
+          description: |
+            The number of seconds to wait before allowing a follow-up request.
+          required: false
+          schema:
+            $ref: "#/components/schemas/RetryAfter"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Errors"
+        text/*:
+          schema:
+            type: string
+            pattern: "^[ -~]{0,65535}$"
+            minLength: 0
+            maxLength: 65535
+
+    TooManyRequestsError:
+      description: Too many requests. The client has exceeded the rate limit or quota.
+      headers:
+        Access-Control-Allow-Origin:
+          description: |
+            Indicates whether the response can be shared with requesting code
+            from the given origin.
+          required: false
+          schema:
+            $ref: "#/components/schemas/AccessControlAllowOrigin"
+        RateLimit-Limit:
+          description: The number of allowed requests in the current period.
+          required: false
+          schema:
+            $ref: "#/components/schemas/RateLimitLimit"
+        RateLimit-Reset:
+          description: The number of seconds left in the current period
+          required: false
+          schema:
+            $ref: "#/components/schemas/RateLimitReset"
+        Retry-After:
+          description: |
+            The number of seconds to wait before allowing a follow-up request.
+          required: false
+          schema:
+            $ref: "#/components/schemas/RetryAfter"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Errors"
+        text/*:
+          schema:
+            type: string
+            pattern: "^[ -~]{0,65535}$"
+            minLength: 0
+            maxLength: 65535
+
+    InternalServerError:
+      description: Internal server error. An unexpected error occurred on the server side.
       headers:
         Access-Control-Allow-Origin:
           description: |


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

This PR improves the OpenAPI specifications across four files by replacing generic, catch-all error response references with HTTP-status-specific named response components, and by fixing incorrect response labels.

#### `src/srtp/api/pagopa/activation.yaml`
- Replaced all `$ref: '#/components/responses/Error'` usages with typed response refs across all endpoints (`POST /activations`, `GET /activations`, `GET /activations/{activationId}`, `DELETE /activations/{activationId}`, `POST /activations/takeover/{otp}`, `GET /activations/payer/{payerId}`):
  - `400` → `BadRequestError`
  - `401` → `UnauthorizedError`
  - `403` → `ForbiddenError`
  - `404` → `NotFoundError`
  - `415` → `UnsupportedMediaTypeError`
  - `429` → `TooManyRequestsError`
  - `500` → `InternalServerError`
- Removed the `406 Not Acceptable` status code from all endpoints (not enforced by the service implementation).
- Removed the `415 Unsupported Media Type` status code from `POST /activations/takeover/{otp}`.
- Added 7 new named response components under `components/responses`, each with a specific description, standard headers, and content schema.
- Updated descriptions for the `ConflictError` and `Error` components to be more precise.

#### `src/srtp/api/epc/callback.openapi.yaml`
- Fixed incorrect response label: both `POST /send` and `POST /cancel` were referencing `$ref: Unauthorized` for HTTP `403` — corrected to `$ref: Forbidden`.
- Added `ErrorModelType2` schema representing the error format returned by the Spring WebFlux gateway layer (fields: `timestamp`, `path`, `status`, `error`, `requestId`).
- Updated all existing response components (`BadRequest`, `Unauthorized`, `NotFound`, `NotAcceptable`, `Conflict`, `Gone`, `UnsupportedMediaType`, `TooManyRequests`) to return a `oneOf: [ErrorModel, ErrorModelType2]` schema, reflecting real server behaviour where both formats may be returned.
- Added new `Forbidden` and `InternalServerError` response components (same structure, with `oneOf`).
- Added `415 UnsupportedMediaType` and `500 InternalServerError` status codes to both `POST /send` and `POST /cancel`.

#### `src/srtp/api/pagopa/payees_registry.yaml`
- Replaced all `$ref: '#/components/responses/Error'` usages with typed response refs for the `GET /payees` endpoint:
  - `400` → `BadRequestError`
  - `401` → `UnauthorizedError`
  - `403` → `ForbiddenError`
  - `429` → `TooManyRequestsError`
  - `500` → `InternalServerError`
- Removed the `406 Not Acceptable` status code (not enforced by the service implementation).
- Added 5 new named response components under `components/responses` with specific descriptions.

#### `src/srtp/api/pagopa/service_providers_registry.yaml`
- Replaced all `$ref: "#/components/responses/Error"` usages with typed response refs for the `GET /service-providers` endpoint:
  - `400` → `BadRequestError`
  - `401` → `UnauthorizedError`
  - `403` → `ForbiddenError`
  - `429` → `TooManyRequestsError`
  - `500` → `InternalServerError`
- Removed the `406 Not Acceptable` status code (not enforced by the service implementation).
- Added 5 new named response components under `components/responses` with specific descriptions.

### Motivation and context

All four OpenAPI specs were using a single generic `Error` (or `Unauthorized`) response component for every HTTP error status code, regardless of the actual error class. This made it impossible for API consumers — code generators, documentation tools, and APIM policies — to distinguish between different error types from the spec alone.

This PR introduces dedicated, named response components for each HTTP error class, making the API contract self-documenting and accurate. The `default` catch-all still references the generic `Error` component for truly unexpected responses. The `406` status code was removed across all specs as it is not enforced by any service implementation.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [x] DEV
- [x] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
