### PR TITLE
feat: [SRTP-1930] Update send.openapi.yaml to new version

### DIFF
--- a/src/srtp/api/pagopa/send.openapi.yaml
+++ b/src/srtp/api/pagopa/send.openapi.yaml
@@ -370,6 +370,31 @@ components:
         - code
         - description
         - rtp
+      example:
+        code: "01000000F"
+        description: "Wrong party identifier"
+        rtp:
+          resourceId: "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+          noticeNumber: "311111111112222123"
+          amount: 1050.75
+          description: "TARI 2025 payment"
+          expiryDate: "2025-12-31"
+          payerName: "Mario Rossi"
+          payerId: "RSSMRA85T10A562S"
+          payeeName: "Comune di Roma"
+          payeeId: "77777777777"
+          subject: "TARI 2025"
+          savingDateTime: "2025-06-06T08:40:16.781Z"
+          serviceProviderDebtor: "FAKESP01"
+          serviceProviderCreditor: "PA123456789"
+          iban: "IT60X0542811101000000123456"
+          payTrxRef: "ABC/124"
+          flgConf: "flgConf"
+          status: SENT
+          events:
+            - timestamp: "2025-06-06T08:40:16.781Z"
+              precStatus: "CREATED"
+              triggerEvent: "CREATE_RTP"
 
     Error:
       description: Error details.

--- a/src/srtp/api/pagopa/send.openapi.yaml
+++ b/src/srtp/api/pagopa/send.openapi.yaml
@@ -19,7 +19,7 @@ paths:
     get:
       operationId: getDeliveryStatus
       summary: Check PD delivery status to RTP
-      description: Returns the delivery outcome for a debt position (PD) identified by notice number (NAV) and payeeId, based on DB records. The endpoint always responds with 200 and reports the outcome in the payload. If a record with status SENT is found, the PD is considered “PD_RTP_DELIVERED”. If the status is ERROR_SEND or ERROR_SENT, the PD is considered “PD_NOT_DELIVERED”. When available, the response also includes the RTP processing or sending date.
+      description: Returns the delivery outcome for a debt position (PD) identified by notice number (NAV) and payeeId, based on DB records. The endpoint always responds with 200 and reports the outcome in the payload. If a record with status SENT is found, the PD is considered “PD_RTP_DELIVERED”. If the status is ERROR_SEND or ERROR_SENT, the PD is considered “PD_RTP_NOT_DELIVERED”. When available, the response also includes the RTP processing or sending date.
       tags: [ rtps ]
       security:
         - oAuth2: [ admin_rtp_send, payee_read_rtp ]
@@ -272,8 +272,15 @@ paths:
           #description: Unsupported media type. Did you provide application/json?
           $ref: '#/components/responses/GenericError'
         "422":
-          #description: Unprocessable Entity - business rules validation failed.
-          $ref: '#/components/responses/GpdErrorWithRtpResponse'
+          description: >
+            Unprocessable Entity. Returned when business rules validation fails.
+            The response payload wraps the error code, description, and the active RTP state context.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/GpdErrorWithRtp'
+                  - $ref: '#/components/schemas/ErrorSchema'
         "429":
           #description: Too many request.
           $ref: '#/components/responses/GenericError'
@@ -348,6 +355,21 @@ components:
       minimum: 0
       maximum: 999
       example: 401
+
+    GpdErrorWithRtp:
+      type: object
+      description: GPD error response containing both business error context and the associated RTP state.
+      properties:
+        code:
+          $ref: '#/components/schemas/ErrorCode'
+        description:
+          $ref: '#/components/schemas/ErrorDescription'
+        rtp:
+          $ref: '#/components/schemas/Rtp'
+      required:
+        - code
+        - description
+        - rtp
 
     Error:
       description: Error details.
@@ -831,47 +853,6 @@ components:
         code: "01000000F"
         description: "Wrong party identifier"
 
-    GpdErrorWithRtp:
-      type: object
-      description: GPD error response containing both business error context and the associated RTP state.
-      additionalProperties: false
-      properties:
-        code:
-          $ref: '#/components/schemas/ErrorCode'
-        description:
-          $ref: '#/components/schemas/ErrorDescription'
-        rtp:
-          $ref: '#/components/schemas/Rtp'
-      required:
-        - code
-        - description
-        - rtp
-      example:
-        code: "01000000F"
-        description: "Wrong party identifier"
-        rtp:
-          resourceId: "3fa85f64-5717-4562-b3fc-2c963f66afa6"
-          noticeNumber: "311111111112222123"
-          amount: 1050.75
-          description: "TARI 2025 payment"
-          expiryDate: "2025-12-31"
-          payerName: "Mario Rossi"
-          payerId: "RSSMRA85T10A562S"
-          payeeName: "Comune di Roma"
-          payeeId: "77777777777"
-          subject: "TARI 2025"
-          savingDateTime: "2025-06-06T08:40:16.781Z"
-          serviceProviderDebtor: "FAKESP01"
-          serviceProviderCreditor: "PA123456789"
-          iban: "IT60X0542811101000000123456"
-          payTrxRef: "ABC/124"
-          flgConf: "flgConf"
-          status: SENT
-          events:
-            - timestamp: "2025-06-06T08:40:16.781Z"
-              precStatus: "CREATED"
-              triggerEvent: "CREATE_RTP"
-
     GpdMessage:
       type: object
       description: >
@@ -1322,39 +1303,6 @@ components:
             type: string
             pattern: "^[ -~]{0,65535}$"
             maxLength: 65535
-
-    GpdErrorWithRtpResponse:
-      description: >
-        Unprocessable Entity. Returned when business rules validation fails.
-        The response payload wraps the error code, description, and the active RTP state context.
-      headers:
-        Access-Control-Allow-Origin:
-          description: |
-            Indicates whether the response can be shared with requesting code
-            from the given origin.
-          required: false
-          schema:
-            $ref: '#/components/schemas/AccessControlAllowOrigin'
-        RateLimit-Limit:
-          description: The number of allowed requests in the current period.
-          required: false
-          schema:
-            $ref: '#/components/schemas/RateLimitLimit'
-        RateLimit-Reset:
-          description: The number of seconds left in the current period
-          required: false
-          schema:
-            $ref: '#/components/schemas/RateLimitReset'
-        Retry-After:
-          description: |
-            The number of seconds to wait before allowing a follow-up request.
-          required: false
-          schema:
-            $ref: '#/components/schemas/RetryAfter'
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/GpdErrorWithRtp'
 
 
 


### PR DESCRIPTION
### List of changes

- Fixed a naming inconsistency in `getDeliveryStatus` description: `PD_NOT_DELIVERED` → `PD_RTP_NOT_DELIVERED`, aligning the status name with the actual enum value used elsewhere in the spec.
- Refactored the `422` response for the `createRtp` endpoint: replaced the `$ref` to the `GpdErrorWithRtpResponse` response component with an inline response definition using a `oneOf` schema (`GpdErrorWithRtp | ErrorSchema`), making the response more flexible by allowing both GPD-specific errors and generic errors.
- Removed the `GpdErrorWithRtpResponse` response component from `components/responses` as it is no longer referenced.
- Cleaned up the `GpdErrorWithRtp` schema: removed `additionalProperties: false` and the inline example, and moved it to an earlier position in `components/schemas` for better readability.

### Motivation and context

The previous `422` response definition for `createRtp` was too rigid — it only allowed `GpdErrorWithRtp` as the response body. In practice, the backend can also return a generic `ErrorSchema` (e.g. for validation errors unrelated to GPD/RTP state). This change makes the spec accurately reflect the actual contract by using `oneOf`.

The `PD_NOT_DELIVERED` typo was a naming inconsistency that could cause confusion when comparing against the actual status enum values (`PD_RTP_NOT_DELIVERED`).

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [x] DEV
- [x] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

Changes are limited to `src/srtp/api/pagopa/send.openapi.yaml`. No new endpoints or schemas are introduced — this is a spec correctness and clarity fix.

---

### If PR is partially applied, why? (reserved to mantainers)

N/A
