### PR TITLE
fix: [SRTP-1932] align send openapi.yaml

### DIFF
--- a/src/srtp/api/pagopa/send.openapi.yaml
+++ b/src/srtp/api/pagopa/send.openapi.yaml
@@ -19,7 +19,7 @@ paths:
     get:
       operationId: getDeliveryStatus
       summary: Check PD delivery status to RTP
-      description: Returns the delivery outcome for a debt position (PD) identified by notice number (NAV) and payeeId, based on DB records. The endpoint always responds with 200 and reports the outcome in the payload. If a record with status SENT is found, the PD is considered “PD_RTP_DELIVERED”. If the status is ERROR_SEND or ERROR_SENT, the PD is considered “PD_NOT_DELIVERED”. When available, the response also includes the RTP processing or sending date.
+      description: Returns the delivery outcome for a debt position (PD) identified by notice number (NAV) and payeeId, based on DB records. The endpoint always responds with 200 and reports the outcome in the payload. If a record with status SENT is found, the PD is considered “PD_RTP_DELIVERED”. If the status is ERROR_SEND or ERROR_SENT, the PD is considered “PD_RTP_NOT_DELIVERED”. When available, the response also includes the RTP processing or sending date.
       tags: [ rtps ]
       security:
         - oAuth2: [ admin_rtp_send, payee_read_rtp ]
@@ -272,8 +272,15 @@ paths:
           #description: Unsupported media type. Did you provide application/json?
           $ref: '#/components/responses/GenericError'
         "422":
-          #description: Unprocessable Entity - business rules validation failed.
-          $ref: '#/components/responses/GpdErrorWithRtpResponse'
+          description: >
+            Unprocessable Entity. Returned when business rules validation fails.
+            The response payload wraps the error code, description, and the active RTP state context.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/GpdErrorWithRtp'
+                  - $ref: '#/components/schemas/ErrorSchema'
         "429":
           #description: Too many request.
           $ref: '#/components/responses/GenericError'
@@ -348,6 +355,21 @@ components:
       minimum: 0
       maximum: 999
       example: 401
+
+    GpdErrorWithRtp:
+      type: object
+      description: GPD error response containing both business error context and the associated RTP state.
+      properties:
+        code:
+          $ref: '#/components/schemas/ErrorCode'
+        description:
+          $ref: '#/components/schemas/ErrorDescription'
+        rtp:
+          $ref: '#/components/schemas/Rtp'
+      required:
+        - code
+        - description
+        - rtp
 
     Error:
       description: Error details.
@@ -831,47 +853,6 @@ components:
         code: "01000000F"
         description: "Wrong party identifier"
 
-    GpdErrorWithRtp:
-      type: object
-      description: GPD error response containing both business error context and the associated RTP state.
-      additionalProperties: false
-      properties:
-        code:
-          $ref: '#/components/schemas/ErrorCode'
-        description:
-          $ref: '#/components/schemas/ErrorDescription'
-        rtp:
-          $ref: '#/components/schemas/Rtp'
-      required:
-        - code
-        - description
-        - rtp
-      example:
-        code: "01000000F"
-        description: "Wrong party identifier"
-        rtp:
-          resourceId: "3fa85f64-5717-4562-b3fc-2c963f66afa6"
-          noticeNumber: "311111111112222123"
-          amount: 1050.75
-          description: "TARI 2025 payment"
-          expiryDate: "2025-12-31"
-          payerName: "Mario Rossi"
-          payerId: "RSSMRA85T10A562S"
-          payeeName: "Comune di Roma"
-          payeeId: "77777777777"
-          subject: "TARI 2025"
-          savingDateTime: "2025-06-06T08:40:16.781Z"
-          serviceProviderDebtor: "FAKESP01"
-          serviceProviderCreditor: "PA123456789"
-          iban: "IT60X0542811101000000123456"
-          payTrxRef: "ABC/124"
-          flgConf: "flgConf"
-          status: SENT
-          events:
-            - timestamp: "2025-06-06T08:40:16.781Z"
-              precStatus: "CREATED"
-              triggerEvent: "CREATE_RTP"
-
     GpdMessage:
       type: object
       description: >
@@ -1322,39 +1303,6 @@ components:
             type: string
             pattern: "^[ -~]{0,65535}$"
             maxLength: 65535
-
-    GpdErrorWithRtpResponse:
-      description: >
-        Unprocessable Entity. Returned when business rules validation fails.
-        The response payload wraps the error code, description, and the active RTP state context.
-      headers:
-        Access-Control-Allow-Origin:
-          description: |
-            Indicates whether the response can be shared with requesting code
-            from the given origin.
-          required: false
-          schema:
-            $ref: '#/components/schemas/AccessControlAllowOrigin'
-        RateLimit-Limit:
-          description: The number of allowed requests in the current period.
-          required: false
-          schema:
-            $ref: '#/components/schemas/RateLimitLimit'
-        RateLimit-Reset:
-          description: The number of seconds left in the current period
-          required: false
-          schema:
-            $ref: '#/components/schemas/RateLimitReset'
-        Retry-After:
-          description: |
-            The number of seconds to wait before allowing a follow-up request.
-          required: false
-          schema:
-            $ref: '#/components/schemas/RetryAfter'
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/GpdErrorWithRtp'
 
 
 

--- a/src/srtp/api/pagopa/send.openapi.yaml
+++ b/src/srtp/api/pagopa/send.openapi.yaml
@@ -272,15 +272,8 @@ paths:
           #description: Unsupported media type. Did you provide application/json?
           $ref: '#/components/responses/GenericError'
         "422":
-          description: >
-            Unprocessable Entity. Returned when business rules validation fails.
-            The response payload wraps the error code, description, and the active RTP state context.
-          content:
-            application/json:
-              schema:
-                oneOf:
-                  - $ref: '#/components/schemas/GpdErrorWithRtp'
-                  - $ref: '#/components/schemas/ErrorSchema'
+          #description: Unprocessable Entity - business rules validation failed.
+          $ref: '#/components/responses/GpdErrorWithRtpResponse'
         "429":
           #description: Too many request.
           $ref: '#/components/responses/GenericError'
@@ -355,21 +348,6 @@ components:
       minimum: 0
       maximum: 999
       example: 401
-
-    GpdErrorWithRtp:
-      type: object
-      description: GPD error response containing both business error context and the associated RTP state.
-      properties:
-        code:
-          $ref: '#/components/schemas/ErrorCode'
-        description:
-          $ref: '#/components/schemas/ErrorDescription'
-        rtp:
-          $ref: '#/components/schemas/Rtp'
-      required:
-        - code
-        - description
-        - rtp
 
     Error:
       description: Error details.
@@ -853,6 +831,47 @@ components:
         code: "01000000F"
         description: "Wrong party identifier"
 
+    GpdErrorWithRtp:
+      type: object
+      description: GPD error response containing both business error context and the associated RTP state.
+      additionalProperties: false
+      properties:
+        code:
+          $ref: '#/components/schemas/ErrorCode'
+        description:
+          $ref: '#/components/schemas/ErrorDescription'
+        rtp:
+          $ref: '#/components/schemas/Rtp'
+      required:
+        - code
+        - description
+        - rtp
+      example:
+        code: "01000000F"
+        description: "Wrong party identifier"
+        rtp:
+          resourceId: "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+          noticeNumber: "311111111112222123"
+          amount: 1050.75
+          description: "TARI 2025 payment"
+          expiryDate: "2025-12-31"
+          payerName: "Mario Rossi"
+          payerId: "RSSMRA85T10A562S"
+          payeeName: "Comune di Roma"
+          payeeId: "77777777777"
+          subject: "TARI 2025"
+          savingDateTime: "2025-06-06T08:40:16.781Z"
+          serviceProviderDebtor: "FAKESP01"
+          serviceProviderCreditor: "PA123456789"
+          iban: "IT60X0542811101000000123456"
+          payTrxRef: "ABC/124"
+          flgConf: "flgConf"
+          status: SENT
+          events:
+            - timestamp: "2025-06-06T08:40:16.781Z"
+              precStatus: "CREATED"
+              triggerEvent: "CREATE_RTP"
+
     GpdMessage:
       type: object
       description: >
@@ -1304,7 +1323,40 @@ components:
             pattern: "^[ -~]{0,65535}$"
             maxLength: 65535
 
-
+    GpdErrorWithRtpResponse:
+      description: >
+        Unprocessable Entity. Returned when business rules validation fails.
+        The response payload wraps the error code, description, and the active RTP state context.
+      headers:
+        Access-Control-Allow-Origin:
+          description: |
+            Indicates whether the response can be shared with requesting code
+            from the given origin.
+          required: false
+          schema:
+            $ref: '#/components/schemas/AccessControlAllowOrigin'
+        RateLimit-Limit:
+          description: The number of allowed requests in the current period.
+          required: false
+          schema:
+            $ref: '#/components/schemas/RateLimitLimit'
+        RateLimit-Reset:
+          description: The number of seconds left in the current period
+          required: false
+          schema:
+            $ref: '#/components/schemas/RateLimitReset'
+        Retry-After:
+          description: |
+            The number of seconds to wait before allowing a follow-up request.
+          required: false
+          schema:
+            $ref: '#/components/schemas/RetryAfter'
+      content:
+        application/json:
+          schema:
+            oneOf:
+              - $ref: '#/components/schemas/GpdErrorWithRtp'
+              - $ref: '#/components/schemas/ErrorSchema'
 
   parameters:
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
- **/gpd/message endpoint**:
  - Updated the 422 response block to use an inline `application/json` schema definition with `oneOf` pointing to either `GpdErrorWithRtp` or `ErrorSchema`.
- **getDeliveryStatus endpoint**:
  - Corrected the description under `getDeliveryStatus` to reference `"PD_RTP_NOT_DELIVERED"` instead of `"PD_NOT_DELIVERED"` to accurately match the return enum values.
<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Aligned the OpenAPI specification on `cstar-securehub-infra-api-spec` to match the actual API contract and models implemented in the `rtp-sender` service.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
