### PR TITLE
feat: SRTP-1929 implement versioning policy for RTP callback and service provider APIs v2

### DIFF
--- a/src/srtp/02_api.tf
+++ b/src/srtp/02_api.tf
@@ -12,7 +12,10 @@ resource "azurerm_api_management_api" "this" {
   service_url           = lookup(each.value, "service_url", null)
   subscription_required = each.value.subscription_required
   version               = lookup(each.value, "version", null)
-  version_set_id        = try(azurerm_api_management_api_version_set.this[each.key].id, null)
+  version_set_id = (
+    contains(keys(each.value), "version_set") ? azurerm_api_management_api_version_set.this[each.key].id :
+    try(azurerm_api_management_api_version_set.this[each.value.version_set_ref].id, null)
+  )
 
   dynamic "import" {
     for_each = try([each.value.import_descriptor], [])

--- a/src/srtp/04_api_operation_policy.tf
+++ b/src/srtp/04_api_operation_policy.tf
@@ -4,7 +4,7 @@ resource "azurerm_api_management_api_operation_policy" "this" {
   api_name            = azurerm_api_management_api.this[each.value.api_name].name
   api_management_name = local.apim_name
   resource_group_name = data.azurerm_api_management.apim.resource_group_name
-  operation_id        = each.key
+  operation_id        = lookup(each.value, "operation_id", each.key)
   xml_content         = each.value.xml_content
 
   depends_on = [

--- a/src/srtp/99_locals.tf
+++ b/src/srtp/99_locals.tf
@@ -140,12 +140,13 @@ locals {
       }
     }
 
-    # RTP CALLBACK
+    # RTP CALLBACK v1
     rtp-callback = {
       description           = "RTP ITN CALLBACK API"
       display_name          = "RTP ITN CALLBACK API"
       path                  = "${local.api_context_path}/cb"
       revision              = "1"
+      version               = "v1"
       protocols             = ["https"]
       service_url           = "${local.api_service_url}/rtpsender/"
       subscription_required = false
@@ -154,9 +155,33 @@ locals {
         content_format = "openapi"
         content_value  = templatefile("./api/epc/callback.openapi.yaml", {})
       }
+      version_set = {
+        name                = "${var.env_short}-rtp-callback-v2"
+        display_name        = "RTP ITN CALLBACK API"
+        versioning_scheme   = "Header"
+        version_header_name = "Version"
+      }
     }
 
-    # RTP Service Provider
+    # RTP CALLBACK v2
+    rtp-callback-v2 = {
+      description           = "RTP ITN CALLBACK API v2"
+      display_name          = "RTP ITN CALLBACK API"
+      path                  = "${local.api_context_path}/cb"
+      revision              = "1"
+      version               = "v2"
+      protocols             = ["https"]
+      service_url           = "${local.api_service_url}/rtpsenderv2/"
+      subscription_required = false
+      product               = "srtp"
+      version_set_ref       = "rtp-callback"
+      import_descriptor = {
+        content_format = "openapi"
+        content_value  = templatefile("./api/epc/callback.openapi.yaml", {})
+      }
+    }
+
+    # RTP Service Provider v1
     rtp-service-provider = {
       description           = "RTP ITN Service Provider API"
       display_name          = "RTP ITN Service Provider API"
@@ -181,6 +206,47 @@ locals {
         xml_content = templatefile("./api/pagopa/send_base_policy.xml", {
           backend_fragment_id = "backend-retry"
         })
+      }
+      api_diagnostic = {
+        name                      = "applicationinsights"
+        sampling_percentage       = 100.0
+        always_log_errors         = true
+        log_client_ip             = true
+        verbosity                 = "information"
+        http_correlation_protocol = "W3C"
+        headers_to_log            = ["RequestId", "X-JWT-Subject", "Version"]
+      }
+    }
+
+    # RTP Service Provider v2 — same version_set as v1, APIM routes natively via Version header
+    rtp-service-provider-v2 = {
+      description           = "RTP ITN Service Provider API v2"
+      display_name          = "RTP ITN Service Provider API"
+      path                  = local.api_context_path
+      revision              = "1"
+      version               = "v2"
+      protocols             = ["https"]
+      service_url           = "${local.api_service_url}/rtpsenderv2/"
+      subscription_required = false
+      product               = "srtp"
+      version_set_ref       = "rtp-service-provider"
+      import_descriptor = {
+        content_format = "openapi"
+        content_value  = templatefile("./api/pagopa/send.openapi.yaml", {})
+      }
+      api_policy = {
+        xml_content = templatefile("./api/pagopa/send_base_policy.xml", {
+          backend_fragment_id = "backend-retry"
+        })
+      }
+      api_diagnostic = {
+        name                      = "applicationinsights"
+        sampling_percentage       = 100.0
+        always_log_errors         = true
+        log_client_ip             = true
+        verbosity                 = "information"
+        http_correlation_protocol = "W3C"
+        headers_to_log            = ["RequestId", "X-JWT-Subject", "Version"]
       }
     }
 
@@ -345,6 +411,14 @@ locals {
       }
       createRtp = {
         api_name = "rtp-service-provider"
+        xml_content = templatefile("./api/pagopa/send_policy.xml", {
+          fragment_id = "rtp-validate-token-mcshared-v2",
+          enableAuth  = var.enable_auth_send
+        })
+      }
+      createRtp-v2 = {
+        api_name     = "rtp-service-provider-v2"
+        operation_id = "createRtp"
         xml_content = templatefile("./api/pagopa/send_policy.xml", {
           fragment_id = "rtp-validate-token-mcshared-v2",
           enableAuth  = var.enable_auth_send


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

- Refactored `azurerm_api_management_api` to support both defining a new `version_set` or referencing an existing one via `version_set_ref`.
- Updated `azurerm_api_management_api_operation_policy` to allow custom `operation_id` overrides.
- Configured header-based versioning (Header `Version`) for the **RTP ITN CALLBACK API** and **RTP ITN Service Provider API**.
- Added version `v1` to the existing `rtp-callback` and `rtp-service-provider` APIs.
- Added Application Insights diagnostics to the `rtp-service-provider` API.
- Introduced the new `rtp-callback-v2` API definition routing to the `/rtpsenderv2/` backend.
- Introduced the new `rtp-service-provider-v2` API definition routing to the `/rtpsenderv2/` backend, utilizing the `send_base_policy.xml` and `send.openapi.yaml`.
- Created the `createRtp-v2` operation policy pointing to the `rtp-validate-token-mcshared-v2` validation fragment.

### Motivation and context

This PR introduces header-based API versioning for the RTP Sender APIs (Callback and Service Provider) to support a new `v2` backend (`/rtpsenderv2/`). It enables seamless side-by-side execution of `v1` and `v2` APIs by routing traffic based on the `Version` header, without impacting existing consumers.

### Type of changes

- [x] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [x] DEV
- [x] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

N/A

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
