### PR TITLE
fix: [SRTP-1943] update fiscal code regex

### DIFF
--- a/src/srtp/api/pagopa/activation.yaml
+++ b/src/srtp/api/pagopa/activation.yaml
@@ -695,7 +695,7 @@ components:
 
         It is used as identifier of the Payer (P009) and of the Payee (E005).
       type: string
-      pattern: "^(([A-Z]{6}\\d{2}[A-Z]\\d{2}([A-Y]\\d{3}|Z[A-Z0-9]{3})[A-Z])|(\\d{11}))$"
+      pattern: "^(?:(?:[A-Z][AEIOUX][AEIOUX]|[B-DF-HJ-NP-TV-Z]{2}[A-Z]){2}(?:[\\dLMNP-V]{2}(?:[A-EHLMPR-T](?:[04LQ][1-9MNP-V]|[15MR][\\dLMNP-V]|[26NS][0-8LMNP-U])|[DHPS][37PT][0L]|[ACELMRT][37PT][01LM]|[AC-EHLMPR-T][26NS][9V])|(?:[02468LNQSU][048LQU]|[13579MPRTV][26NS])B[26NS][9V])(?:[A-MZ][1-9MNP-V][\\dLMNP-V]{2}|[A-M][0L](?:[1-9MNP-V][\\dLMNP-V]|[0L][1-9MNP-V]))[A-Z]|\\d{11})$"
       minLength: 11
       maxLength: 16
       example: "RSSMRA85T10A562S"

--- a/src/srtp/api/pagopa/send.openapi.yaml
+++ b/src/srtp/api/pagopa/send.openapi.yaml
@@ -535,7 +535,7 @@ components:
     PayerId:
       type: string
       description: "The id of the recipient of the request to pay. The id is the fiscal code"
-      pattern: "^(([A-Z]{6}\\d{2}[A-Z]\\d{2}([A-Y]\\d{3}|Z[A-Z0-9]{3})[A-Z])|(\\d{11}))$"
+      pattern: "^(?:(?:[A-Z][AEIOUX][AEIOUX]|[B-DF-HJ-NP-TV-Z]{2}[A-Z]){2}(?:[\\dLMNP-V]{2}(?:[A-EHLMPR-T](?:[04LQ][1-9MNP-V]|[15MR][\\dLMNP-V]|[26NS][0-8LMNP-U])|[DHPS][37PT][0L]|[ACELMRT][37PT][01LM]|[AC-EHLMPR-T][26NS][9V])|(?:[02468LNQSU][048LQU]|[13579MPRTV][26NS])B[26NS][9V])(?:[A-MZ][1-9MNP-V][\\dLMNP-V]{2}|[A-M][0L](?:[1-9MNP-V][\\dLMNP-V]|[0L][1-9MNP-V]))[A-Z]|\\d{11})$"
       example: "ABCDEF12G34H567I"
 
     PayeeId:
@@ -660,7 +660,7 @@ components:
           type: string
           minLength: 11
           maxLength: 16
-          pattern: "^(([A-Z]{6}\\d{2}[A-Z]\\d{2}([A-Y]\\d{3}|Z[A-Z0-9]{3})[A-Z])|(\\d{11}))$"
+          pattern: "^(?:(?:[A-Z][AEIOUX][AEIOUX]|[B-DF-HJ-NP-TV-Z]{2}[A-Z]){2}(?:[\\dLMNP-V]{2}(?:[A-EHLMPR-T](?:[04LQ][1-9MNP-V]|[15MR][\\dLMNP-V]|[26NS][0-8LMNP-U])|[DHPS][37PT][0L]|[ACELMRT][37PT][01LM]|[AC-EHLMPR-T][26NS][9V])|(?:[02468LNQSU][048LQU]|[13579MPRTV][26NS])B[26NS][9V])(?:[A-MZ][1-9MNP-V][\\dLMNP-V]{2}|[A-M][0L](?:[1-9MNP-V][\\dLMNP-V]|[0L][1-9MNP-V]))[A-Z]|\\d{11})$"
           example: "RSSMRA85T10A562S"
         payeeName:
           type: string
@@ -909,7 +909,7 @@ components:
           pattern: "^(\\d{11}|\\d{16})$"
         debtor_tax_code:
           type: string
-          pattern: "^(([A-Z]{6}\\d{2}[A-Z]\\d{2}([A-Y]\\d{3}|Z[A-Z0-9]{3})[A-Z])|(\\d{11}))$"
+          pattern: "^(?:(?:[A-Z][AEIOUX][AEIOUX]|[B-DF-HJ-NP-TV-Z]{2}[A-Z]){2}(?:[\\dLMNP-V]{2}(?:[A-EHLMPR-T](?:[04LQ][1-9MNP-V]|[15MR][\\dLMNP-V]|[26NS][0-8LMNP-U])|[DHPS][37PT][0L]|[ACELMRT][37PT][01LM]|[AC-EHLMPR-T][26NS][9V])|(?:[02468LNQSU][048LQU]|[13579MPRTV][26NS])B[26NS][9V])(?:[A-MZ][1-9MNP-V][\\dLMNP-V]{2}|[A-M][0L](?:[1-9MNP-V][\\dLMNP-V]|[0L][1-9MNP-V]))[A-Z]|\\d{11})$"
         nav:
           type: string
           minLength: 15

--- a/src/srtp/api/pagopa/sender.openapi.yaml
+++ b/src/srtp/api/pagopa/sender.openapi.yaml
@@ -338,7 +338,7 @@ components:
 
         debtor_tax_code:
           type: string
-          pattern: '^(([A-Z]{6}\d{2}[A-Z]\d{2}[A-Z]\d{3}[A-Z])|(\d{11}))$'
+          pattern: "^(?:(?:[A-Z][AEIOUX][AEIOUX]|[B-DF-HJ-NP-TV-Z]{2}[A-Z]){2}(?:[\\dLMNP-V]{2}(?:[A-EHLMPR-T](?:[04LQ][1-9MNP-V]|[15MR][\\dLMNP-V]|[26NS][0-8LMNP-U])|[DHPS][37PT][0L]|[ACELMRT][37PT][01LM]|[AC-EHLMPR-T][26NS][9V])|(?:[02468LNQSU][048LQU]|[13579MPRTV][26NS])B[26NS][9V])(?:[A-MZ][1-9MNP-V][\\dLMNP-V]{2}|[A-M][0L](?:[1-9MNP-V][\\dLMNP-V]|[0L][1-9MNP-V]))[A-Z]|\\d{11})$"
 
         nav:
           type: string

--- a/src/srtp/api/pagopa/takeover.yaml
+++ b/src/srtp/api/pagopa/takeover.yaml
@@ -93,7 +93,7 @@ components:
 
             It is used as identifier of the Payer (P009) and of the Payee (E005).
           type: string
-          pattern: "^(([A-Z]{6}\\d{2}[A-Z]\\d{2}([A-Y]\\d{3}|Z[A-Z0-9]{3})[A-Z])|(\\d{11}))$"
+          pattern: "^(?:(?:[A-Z][AEIOUX][AEIOUX]|[B-DF-HJ-NP-TV-Z]{2}[A-Z]){2}(?:[\\dLMNP-V]{2}(?:[A-EHLMPR-T](?:[04LQ][1-9MNP-V]|[15MR][\\dLMNP-V]|[26NS][0-8LMNP-U])|[DHPS][37PT][0L]|[ACELMRT][37PT][01LM]|[AC-EHLMPR-T][26NS][9V])|(?:[02468LNQSU][048LQU]|[13579MPRTV][26NS])B[26NS][9V])(?:[A-MZ][1-9MNP-V][\\dLMNP-V]{2}|[A-M][0L](?:[1-9MNP-V][\\dLMNP-V]|[0L][1-9MNP-V]))[A-Z]|\\d{11})$"
           minLength: 11
           maxLength: 16
           example: "RSSMRA85T10A562S"


### PR DESCRIPTION
### List of changes

Updated the regular expression used to validate the Italian fiscal code (`codice fiscale`) across the OpenAPI specifications:

- `src/srtp/api/pagopa/activation.yaml`
- `src/srtp/api/pagopa/send.openapi.yaml` (3 occurrences: `PayerId`, `payerTaxCode`, `debtor_tax_code`)
- `src/srtp/api/pagopa/sender.openapi.yaml` (`debtor_tax_code`)
- `src/srtp/api/pagopa/takeover.yaml`

The previous pattern only performed a loose structural check (`[A-Z]{6}\d{2}[A-Z]\d{2}([A-Y]\d{3}|Z[A-Z0-9]{3})[A-Z]` for natural persons, or 11 digits for legal entities). It has been replaced with a stricter pattern that validates the actual encoding rules of the Italian fiscal code, while still accepting an 11-digit VAT/legal-entity code as an alternative.

### Motivation and context

The looser regex accepted fiscal codes that are not actually valid according to the official Italian fiscal code algorithm, allowing malformed values to pass validation. The new pattern aligns the API contract with the real fiscal code format, reducing the risk of invalid identifiers being accepted by the endpoints.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [x] DEV
- [x] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->