### PR TITLE
feat: [SRTP-1981] Add EPC mock v4.0

### DIFF
--- a/src/srtp/99_locals.tf
+++ b/src/srtp/99_locals.tf
@@ -288,18 +288,42 @@ locals {
     }
     },
     var.env_short == "p" ? {} : {
-      # RTP Mock
+      # RTP Mock v1 (EPC v3.1)
       rtp-mock = {
         description           = "RTP ITN MOCK API EPC"
         display_name          = "RTP ITN MOCK API EPC"
         path                  = "${local.api_context_path}/mock"
         revision              = "1"
+        version               = "v1"
         protocols             = ["https"]
         subscription_required = false
         product               = "srtp"
         import_descriptor = {
           content_format = "openapi"
           content_value  = templatefile("./api/epc/EPC133-22_v3.1_SRTP_spec.openapi.yaml", {})
+        }
+        version_set = {
+          name                = "${var.env_short}-rtp-mock-epc"
+          display_name        = "RTP ITN MOCK API EPC"
+          versioning_scheme   = "Header"
+          version_header_name = "Version"
+        }
+      }
+
+      # RTP Mock v2 (EPC V4.0)
+      rtp-mock-v4 = {
+        description           = "RTP ITN MOCK API EPC V4.0"
+        display_name          = "RTP ITN MOCK API EPC"
+        path                  = "${local.api_context_path}/mock"
+        revision              = "1"
+        version               = "v2"
+        protocols             = ["https"]
+        subscription_required = false
+        product               = "srtp"
+        version_set_ref       = "rtp-mock"
+        import_descriptor = {
+          content_format = "openapi"
+          content_value  = templatefile("./api/epc/EPC133-22 v1.0 SRTP API YAML V4.0.yaml", {})
         }
       }
 
@@ -439,6 +463,16 @@ locals {
       postRequestToPayCancellationRequest = {
         api_name    = "rtp-mock"
         xml_content = file("./api/test/mock_policy_epc.xml")
+      }
+      postRequestToPayRequests-v4 = {
+        api_name     = "rtp-mock-v4"
+        operation_id = "postRequestToPayRequests"
+        xml_content  = file("./api/test/mock_policy_epc_v4.xml")
+      }
+      postRequestToPayCancellationRequest-v4 = {
+        api_name     = "rtp-mock-v4"
+        operation_id = "postRequestToPayCancellationRequest"
+        xml_content  = file("./api/test/mock_policy_epc_v4.xml")
       }
       processGpdMessage = {
         api_name    = "rtp-gpd-message-mock"

--- a/src/srtp/99_locals.tf
+++ b/src/srtp/99_locals.tf
@@ -288,10 +288,10 @@ locals {
     }
     },
     { for k, v in {
-      # RTP Mock v1 (EPC v3.2)
+      # RTP Mock v1 (EPC v3.1)
       rtp-mock = var.env_short == "p" ? null : {
-        description           = "RTP ITN MOCK API EPC V3.2"
-        display_name          = "RTP ITN MOCK API EPC V3.2"
+        description           = "RTP ITN MOCK API EPC V3.1"
+        display_name          = "RTP ITN MOCK API EPC V3.1"
         path                  = "${local.api_context_path}/mock"
         revision              = "1"
         version               = "v1"

--- a/src/srtp/99_locals.tf
+++ b/src/srtp/99_locals.tf
@@ -287,9 +287,9 @@ locals {
       }
     }
     },
-    var.env_short == "p" ? {} : {
+    { for k, v in {
       # RTP Mock v1 (EPC v3.2)
-      rtp-mock = {
+      rtp-mock = var.env_short == "p" ? null : {
         description           = "RTP ITN MOCK API EPC V3.2"
         display_name          = "RTP ITN MOCK API EPC V3.2"
         path                  = "${local.api_context_path}/mock"
@@ -311,7 +311,7 @@ locals {
       }
 
       # RTP Mock v2 (EPC V4.0)
-      rtp-mock-v4 = {
+      rtp-mock-v4 = var.env_short == "p" ? null : {
         description           = "RTP ITN MOCK API EPC V4.0"
         display_name          = "RTP ITN MOCK API EPC V4.0"
         path                  = "${local.api_context_path}/mock"
@@ -328,7 +328,7 @@ locals {
       }
 
       # RTP GPD Message Processing Mock
-      rtp-gpd-message-mock = {
+      rtp-gpd-message-mock = var.env_short == "p" ? null : {
         description           = "RTP ITN GPD Message Mock API"
         display_name          = "RTP ITN GPD Message Mock API"
         path                  = "${local.api_context_path}/mock/gpd"
@@ -343,7 +343,7 @@ locals {
       }
 
       # RTP Takeover Mock
-      rtp-takeover-mock = {
+      rtp-takeover-mock = var.env_short == "p" ? null : {
         description           = "RTP ITN MOCK API TAKEOVER"
         display_name          = "RTP ITN MOCK API TAKEOVER"
         path                  = "${local.api_context_path}/mock/takeover"
@@ -356,7 +356,7 @@ locals {
           content_value  = templatefile("./api/pagopa/takeover.yaml", {})
         }
       }
-    }
+    } : k => v if v != null }
   )
   products = {
     # SRTP
@@ -455,33 +455,33 @@ locals {
         })
       }
     },
-    var.env_short == "p" ? {} : {
-      postRequestToPayRequests = {
+    { for k, v in {
+      postRequestToPayRequests = var.env_short == "p" ? null : {
         api_name    = "rtp-mock"
         xml_content = file("./api/test/mock_policy_epc.xml")
       }
-      postRequestToPayCancellationRequest = {
+      postRequestToPayCancellationRequest = var.env_short == "p" ? null : {
         api_name    = "rtp-mock"
         xml_content = file("./api/test/mock_policy_epc.xml")
       }
-      postRequestToPayRequests-v4 = {
+      postRequestToPayRequests-v4 = var.env_short == "p" ? null : {
         api_name     = "rtp-mock-v4"
         operation_id = "postRequestToPayRequests"
         xml_content  = file("./api/test/mock_policy_epc_v4.xml")
       }
-      postRequestToPayCancellationRequest-v4 = {
+      postRequestToPayCancellationRequest-v4 = var.env_short == "p" ? null : {
         api_name     = "rtp-mock-v4"
         operation_id = "postRequestToPayCancellationRequest"
         xml_content  = file("./api/test/mock_policy_epc_v4.xml")
       }
-      processGpdMessage = {
+      processGpdMessage = var.env_short == "p" ? null : {
         api_name    = "rtp-gpd-message-mock"
         xml_content = file("./api/test/mock_policy_gpd.xml")
       }
-      notifyUserTakeover = {
+      notifyUserTakeover = var.env_short == "p" ? null : {
         api_name    = "rtp-takeover-mock"
         xml_content = file("./api/test/mock_policy_takeover.xml")
       }
-    }
+    } : k => v if v != null }
   )
 }

--- a/src/srtp/99_locals.tf
+++ b/src/srtp/99_locals.tf
@@ -288,10 +288,10 @@ locals {
     }
     },
     var.env_short == "p" ? {} : {
-      # RTP Mock v1 (EPC v3.1)
+      # RTP Mock v1 (EPC v3.2)
       rtp-mock = {
-        description           = "RTP ITN MOCK API EPC"
-        display_name          = "RTP ITN MOCK API EPC"
+        description           = "RTP ITN MOCK API EPC V3.2"
+        display_name          = "RTP ITN MOCK API EPC V3.2"
         path                  = "${local.api_context_path}/mock"
         revision              = "1"
         version               = "v1"
@@ -313,7 +313,7 @@ locals {
       # RTP Mock v2 (EPC V4.0)
       rtp-mock-v4 = {
         description           = "RTP ITN MOCK API EPC V4.0"
-        display_name          = "RTP ITN MOCK API EPC"
+        display_name          = "RTP ITN MOCK API EPC V4.0"
         path                  = "${local.api_context_path}/mock"
         revision              = "1"
         version               = "v2"

--- a/src/srtp/api/epc/EPC133-22 v1.0 SRTP API YAML V4.0.yaml
+++ b/src/srtp/api/epc/EPC133-22 v1.0 SRTP API YAML V4.0.yaml
@@ -1,0 +1,4174 @@
+openapi: 3.0.3
+info:
+  title: |
+    SEPA Request-To-Pay (SRTP) inter-SP (Service Providers) API
+    Version V4.0 202500620
+  description: |
+    Technical specification for the SEPA REQUEST TO PAY (SRTP) Application Programming Interface
+    # Overview
+    Please refer to §5 of SEPA Request-to-Pay scheme rulebook as a glossary of useful terms and abbreviation being used.
+
+    This API specification aims to describe the different interactions between two actors:
+    * the Payee's SRTP-SP being the API client
+    * the Payer's SRTP-SP being the API server
+
+    Since some interactions may not be completed synchronously, a callback URL must be set by the API client in order to allow the API server to send back an asynchronous response.
+    # Technical choices
+    ## Character case
+    the following character case conventions are used:
+    * UpperCamelCase for Components Definitions name
+    * lowerCamelCase for Properties name
+    * spinal-case for Path components
+    ## API Resource Structure
+    Each API resource declared within this specification may include the following elements:
+    * A resource Identifier that can only be set by the API server
+    * A callback URL that must be set by the API client before posting the relevant resource
+    * A wrapper embedding the relevant SRTP-scheme dataset
+    * A HATEOAS block providing further possible API interactions
+    Other Documentation:
+    * SEPA Request-To-Pay Scheme Rulebook - Version 4.0 - EPC014-20
+    * SEPA Request-To-Pay Inter-SRTP SP API Specifications - EPC013-25
+    * SEPA Request-To-Pay Implementation Guidelines - Inter-RTP Service Provider SRTP - Version 4.0 - EPC259-22
+    * EPC API Security Framework - EPC164-22
+    url: https://www.europeanpaymentscouncil.eu/what-we-do/other-schemes/sepa-request-pay
+  contact:
+    name: European Payment Council
+    url: 'https://www.europeanpaymentscouncil.eu/'
+    email: 'contact@epc-cep.eu'
+  license:
+    name: 'CC-BY'
+    url: 'https://wellcome.org/grant-funding/guidance/open-access-guidance/creative-commons-attribution-licence-cc'
+  version: "4.0"
+servers:
+- url: 'http://server/v1'
+paths:
+  /sepa-request-to-pay-requests:
+    post:
+      summary: 'Posting a SEPA Request-To-Pay to the Payer''s SRTP-Service Provider'
+      description: |
+        # Generic flow
+        The Payee's SRTP-SP, acting as an API client, posts a SEPA-Request-To-Pay to the API server of the Payer's SRTP-SP.
+        * it may have requested a functional positive confirmation thought the setting of AT-S007.
+
+        When the API server is able to accept and process the posted resource, it answers with a HTTP201 response
+        * If a functional positive confirmation was requested by the API client,
+          * this confirmation may be returned within the HTTP201 response if the API server is able to do so.
+          * otherwise, this confirmation will be sent later through the callback URL provided by the API client.
+
+        When the API server is not able to accept or process the posted resource, it answers with a HTTP400 response embedding the reject of the SEPA Request-To-Pay.
+
+        However the API server, when unable to reject immediately a SEPA Request-To-Pay that it cannot process, is able to use the callback URL provided by the API client in order to forward later this reject.
+      externalDocs:
+        description: § 2.1 in SRTP Implementation guidelines 4.0
+        url: ''
+      operationId: postRequestToPayRequests
+      parameters:
+      - $ref: '#/components/parameters/Idempotency'
+      - $ref: '#/components/parameters/Correlation'
+      requestBody:
+        description: ISO20022 based SEPA Request-To-Pay
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SepaRequestToPayRequestResource'
+        required: true
+      responses:
+        201:
+          description: |
+            This response states that the resource has been successfully created on the server side.
+            The location header aims to provide the location of the successfully created resource.
+          headers:
+            location:
+              $ref: '#/components/headers/Location'
+            Correlation:
+              $ref: '#/components/headers/X-Request-ID'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SynchronousSepaRequestToPayCreationResponse'
+        400:
+          description: |
+            This response states that the resource creation has been rejected by the server.
+
+            § 2.2 in SRTP Implementation guidelines 4.0
+
+            Possible errors:
+            * the posted content does not match a valid SEPA Request-To-Pay structure.
+            * the posted content does match a valid SEPA Request-To-Pay structure but is not compliant with the SRTP scheme.
+            * the posted content does match a valid SEPA Request-To-Pay structure, is scheme-compliant but cannot be processed by the API-server for whatever reason.
+          headers:
+            Correlation:
+              $ref: '#/components/headers/X-Request-ID'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SynchronousSepaRequestToPayErrorResponse'
+        401:
+          $ref: '#/components/responses/Unauthorized'
+        406:
+          $ref: '#/components/responses/NotAcceptable'
+        409:
+          $ref: '#/components/responses/Conflict'
+        415:
+          $ref: '#/components/responses/UnsupportedMediaType'
+        422:
+          description: Unprocessable Entity
+        429:
+          $ref: '#/components/responses/TooManyRequests'
+      callbacks:
+        RequestToPayUpdate:
+          "{$request.body#/callbackUrl}":
+            post:
+              summary: 'Forwarding of a SEPA Request-To-Pay Response to the Payee''s SRTP Service Provider'
+              description: § 2.2, 2.3, 2.5 & 2.6 in SRTP Implementation guidelines 4.0
+              requestBody:
+                description: ISO20022 based SEPA Request-To-Pay Response
+                content:
+                  application/json:
+                    schema:
+                      $ref: '#/components/schemas/AsynchronousSepaRequestToPayResponseResource'
+                required: true
+              responses:
+                400:
+                  description: Bad Request
+                200:
+                  description: the callback server accepts the callback
+  /sepa-request-to-pay-requests/{sepaRequestToPayRequestResourceId}:
+    get:
+      summary: 'Retrieving of a SEPA Payment Request from the Payer''s SRTP-Service Provider'
+      description: |
+        The Payee's SRTP-SP, acting as an API client, request the retrieval of a given SEPA-Request-To-Pay to the API server of the Payer's SRTP-SP.
+        The API server, if it can retrieve the relevant resource, answers with this resource.
+        This request could be useful for the API client in case of conflict when trying to post a SEPA Request-To-Pay. Actually the API-client is then able to check the pre-existing SEPA Request-To-Pay with the one it intended to post.
+
+        >CAUTION: This is NOT a SRTP Implementation guidelines 4.0 interaction.
+      operationId: getPaymentRequest
+      parameters:
+      - $ref: '#/components/parameters/Correlation'
+      - $ref: '#/components/parameters/SepaRequestToPayRequestResourceId'
+      responses:
+        200:
+          description: The response contains the requested SEPA Payment Request Resource
+          headers:
+            Correlation:
+              $ref: '#/components/headers/X-Request-ID'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SepaRequestToPayRequestResource'
+        400:
+          $ref: '#/components/responses/BadRequest'
+        401:
+          $ref: '#/components/responses/Unauthorized'
+        404:
+          $ref: '#/components/responses/NotFound'
+        406:
+          $ref: '#/components/responses/NotAcceptable'
+        410:
+          $ref: '#/components/responses/Gone'
+        429:
+          $ref: '#/components/responses/TooManyRequests'
+  /sepa-request-to-pay-requests/{sepaRequestToPayRequestResourceId}/status-update:
+    post:
+      summary: 'Requesting a SEPA Request-To-Pay Status Update from the Payer''s SRTP-Service Provider'
+      description: |
+        The Payee's SRTP-SP, acting as an API client, request a status update on a given SEPA-Request-To-Pay to the API server of the Payer's SRTP-SP.
+        When possible, the API server may respond immediately with the status update. Otherwise, it will send later the update through the callback URL provided by the API client.
+      externalDocs:
+        description: § 2.9 in SRTP Implementation guidelines 4.0
+        url: ''
+      operationId: getRequestToPayStatusUpdate
+      parameters:
+      - $ref: '#/components/parameters/Idempotency'
+      - $ref: '#/components/parameters/Correlation'
+      - $ref: '#/components/parameters/SepaRequestToPayRequestResourceId'
+      requestBody:
+        description: |
+          ISO20022 based SEPA Request-To-Pay status update request
+          Actually, the server, based on the relevant SEPA Request-To-Pay resource, has already the pieces of data of this status update request.
+          However, in order to stay as close as possible to the Rulebook, it is proposed that this payload is nevertheless transmitted.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SepaRequestToPayStatusUpdateRequestResource'
+        required: true
+      responses:
+        200:
+          description: The response contains the requested SEPA Request-To-Pay Status Update Resource
+          headers:
+            Correlation:
+              $ref: '#/components/headers/X-Request-ID'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SynchronousSepaRequestToPayStatusUpdateResponse'
+        400:
+          $ref: '#/components/responses/BadRequest'
+        401:
+          $ref: '#/components/responses/Unauthorized'
+        404:
+          $ref: '#/components/responses/NotFound'
+        406:
+          $ref: '#/components/responses/NotAcceptable'
+        410:
+          $ref: '#/components/responses/Gone'
+        415:
+          $ref: '#/components/responses/UnsupportedMediaType'
+        422:
+          description: Unprocessable Entity
+        429:
+          $ref: '#/components/responses/TooManyRequests'
+      callbacks:
+        RequestToPayUpdate:
+          "{$request.body#/callbackUrl}":
+            post:
+              summary: 'Forwarding of a SEPA Request-To-Pay Response to the Payee''s SRTP Service Provider'
+              description: § 2.2, 2.3, 2.5 & 2.3 in SRTP Implementation guidelines 4.0
+              requestBody:
+                description: ISO20022 based SEPA Request-To-Pay Response
+                content:
+                  application/json:
+                    schema:
+                      $ref: '#/components/schemas/SepaRequestToPayStatusUpdateResponseResource'
+                required: true
+              responses:
+                400:
+                  description: Bad Request
+                200:
+                  description: the callback server accepts the callback
+  /sepa-request-to-pay-requests/{sepaRequestToPayRequestResourceId}/cancellation-requests:
+    post:
+      summary: 'Sending of a SEPA Request-To-Pay Cancellation Request to the Payer''s SRTP-Service Provider'
+      description: |
+        The Payee's SRTP-SP, acting as an API client, request the cancellation of a given SEPA-Request-To-Pay to the API server of the Payer's SRTP-SP.
+        When possible, the API server may respond immediately with the cancellation response. Otherwise, it will send later the response through the callback URL provided by the API client.
+      externalDocs:
+        description: § 2.6 in SRTP Implementation guidelines 4.0
+        url: ''
+      operationId: postRequestToPayCancellationRequest
+      parameters:
+      - $ref: '#/components/parameters/Idempotency'
+      - $ref: '#/components/parameters/Correlation'
+      - $ref: '#/components/parameters/SepaRequestToPayRequestResourceId'
+      requestBody:
+        description: |
+          ISO20022 based SEPA Request-To-Pay cancellation request
+          Actually, the server, based on the relevant SEPA Request-To-Pay resource, has already the pieces of data of this cancellation request.
+          However, in order to stay as close as possible to the Rulebook, it is proposed that this payload is nevertheless transmitted.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SepaRequestToPayCancellationRequestResource'
+        required: true
+      responses:
+        201:
+          description: This response states that the resource has been successfully created on the server side.
+          headers:
+            location:
+              $ref: '#/components/headers/Location'
+            Correlation:
+              $ref: '#/components/headers/X-Request-ID'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SynchronousRequestToPayCancellationResponse'
+        400:
+          $ref: '#/components/responses/BadRequest'
+        401:
+          $ref: '#/components/responses/Unauthorized'
+        404:
+          $ref: '#/components/responses/NotFound'
+        406:
+          $ref: '#/components/responses/NotAcceptable'
+        410:
+          $ref: '#/components/responses/Gone'
+        415:
+          $ref: '#/components/responses/UnsupportedMediaType'
+        422:
+          description: Unprocessable Entity
+        429:
+          $ref: '#/components/responses/TooManyRequests'
+      callbacks:
+        CancellationRequestUpdate:
+          "{$request.body#/callbackUrl}":
+            post:
+              summary: 'Posting of a SEPA Request-To-Pay Cancellation Response to the Payee''s SRTP Service Provider'
+              description: § 2.8 & 2.9 in SRTP Implementation guidelines 4.0
+              requestBody:
+                description: ISO20022 based SEPA Request-To-Pay Cancellation Response
+                content:
+                  application/json:
+                    schema:
+                      $ref: '#/components/schemas/SepaRequestToPayCancellationResponseResource'
+                required: true
+              responses:
+                400:
+                  description: Bad Request
+                200:
+                  description: the callback server accepts the callback
+  /sepa-request-to-pay-requests/{sepaRequestToPayRequestResourceId}/cancellation-requests/{sepaRequestToPayCancellationResourceId}/status-update:
+    post:
+      summary: 'Requesting a SEPA Request-To-Pay Cancellation Request Status Update from the Payer''s SRTP-Service Provider'
+      description: |
+        The Payee's SRTP-SP, acting as an API client, request a status update on a given SEPA-Request-To-Pay Cancellation Request to the API server of the Payer's SRTP-SP.
+        When possible, the API server may respond immediately with the status update. Otherwise, it will send later the update through the callback URL provided by the API client.
+        This request is idempotent since requesting twice the cancellation of a given SEPA-request-to-pay will obviously get the same result.
+      externalDocs:
+        description: § 2.10 in SRTP Implementation guidelines 4.0
+        url: ''
+      operationId: getRequestToPayCancellationStatusUpdate
+      parameters:
+      - $ref: '#/components/parameters/Idempotency'
+      - $ref: '#/components/parameters/Correlation'
+      - $ref: '#/components/parameters/SepaRequestToPayRequestResourceId'
+      - $ref: '#/components/parameters/SepaRequestToPayCancellationResourceId'
+      requestBody:
+        description: |
+          ISO20022 based SEPA Request-To-Pay Cancellation Status Update Request
+          Actually, the server, based on the relevant SEPA Request-To-Pay resource, has already the pieces of data of this cancellation status update request.
+          However, in order to stay as close as possible to the Rulebook, it is proposed that this payload is nevertheless transmitted.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SepaRequestToPayCancellationStatusUpdateRequestResource'
+        required: true
+      responses:
+        200:
+          description: The response contains the requested SEPA Request-To-Pay Cancellation Status Update Response Resource
+          headers:
+            Correlation:
+              $ref: '#/components/headers/X-Request-ID'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SynchronousSepaRequestToPayCancellationStatusUpdateResponse'
+        400:
+          $ref: '#/components/responses/BadRequest'
+        401:
+          $ref: '#/components/responses/Unauthorized'
+        404:
+          $ref: '#/components/responses/NotFound'
+        406:
+          $ref: '#/components/responses/NotAcceptable'
+        410:
+          $ref: '#/components/responses/Gone'
+        415:
+          $ref: '#/components/responses/UnsupportedMediaType'
+        422:
+          description: Unprocessable Entity
+        429:
+          $ref: '#/components/responses/TooManyRequests'
+      callbacks:
+        RequestToPayUpdate:
+          "{$request.body#/callbackUrl}":
+            post:
+              summary: 'Forwarding of a SEPA Request-To-Pay Cancellation Status Update Response to the Payee''s SRTP Service Provider'
+              description: § 2.13 in SRTP Implementation guidelines 4.0
+              requestBody:
+                description: ISO20022 based SEPA Request-To-Pay Cancellation Status Update
+                content:
+                  application/json:
+                    schema:
+                      $ref: '#/components/schemas/SepaRequestToPayCancellationStatusUpdateResponseResource'
+                required: true
+              responses:
+                400:
+                  description: Bad Request
+                200:
+                  description: the callback server accepts the callback
+components:
+  schemas:
+    SynchronousSepaRequestToPayErrorResponse:
+      oneOf:
+      - $ref: '#/components/schemas/SepaRequestToPayErrorResponseResource_DS04b'
+      - $ref: '#/components/schemas/ErrorModel'
+    SynchronousSepaRequestToPayCreationResponse:
+      oneOf:
+      - $ref: '#/components/schemas/RedirectSepaRequestToPayResponseResource_DS05'
+      - $ref: '#/components/schemas/VoidResponse'
+    SynchronousSepaRequestToPayCancellationStatusUpdateResponse:
+      oneOf:
+      - $ref: '#/components/schemas/SepaRequestToPayCancellationStatusUpdateResponseResource'
+      - $ref: '#/components/schemas/VoidResponse'
+    SynchronousRequestToPayCancellationResponse:
+      oneOf:
+      - $ref: '#/components/schemas/SepaRequestToPayCancellationResponseResource'
+      - $ref: '#/components/schemas/VoidResponse'
+    SynchronousSepaRequestToPayStatusUpdateResponse:
+      oneOf:
+      - $ref: '#/components/schemas/SepaRequestToPayStatusUpdateResponseResource'
+      - $ref: '#/components/schemas/VoidResponse'
+    ErrorDetail:
+      type: object
+      properties:
+        location:
+          enum:
+          - header
+          - query
+          type: string
+        name:
+          type: string
+        path:
+          type: string
+        erroneousValue:
+          type: string
+        message:
+          type: string
+        expectedPattern:
+          type: string
+        expectedValueRange:
+          type: object
+          properties:
+            minValue:
+              type: integer
+            maxValue:
+              type: integer
+        expectedValueCount:
+          type: object
+          properties:
+            minValue:
+              type: integer
+            maxValue:
+              type: integer
+        expectedEnumeration:
+          type: array
+          items:
+            type: string
+    ErrorModel:
+      type: object
+      properties:
+        timestamp:
+          type: string
+          format: date-time
+        status:
+          type: integer
+          format: int32
+        error:
+          maxLength: 140
+          type: string
+        message:
+          maxLength: 140
+          type: string
+        path:
+          maxLength: 140
+          type: string
+        details:
+          type: array
+          items:
+            $ref: '#/components/schemas/ErrorDetail'
+          minItems: 1
+      required:
+      - status
+      - message
+    ResourceId:
+      type: string
+    GenericHalLink:
+      type: object
+      properties:
+        href:
+          type: string
+        templated:
+          type: boolean
+          default: false
+      required:
+      - href
+    VoidResponse:
+      type: string
+    NegativeSepaRequestToPayResponse_DS08N:
+      type: object
+      properties:
+        Document:
+          $ref: '#/components/schemas/Document_EPC259-22_V4.0_DS08N'
+    PositiveSepaRequestToPayResponse_DS08P:
+      type: object
+      properties:
+        Document:
+          $ref: '#/components/schemas/Document_EPC259-22_V4.0_DS08P'
+    SepaRequestToPayCancellationResponse:
+      oneOf:
+      - $ref: '#/components/schemas/PositiveSepaRequestToPayCancellationResponse'
+      - $ref: '#/components/schemas/NegativeSepaRequestToPayCancellationResponse'
+    SepaRequestToPayErrorResponseResource_DS04b:
+      type: object
+      properties:
+        resourceId:
+          $ref: '#/components/schemas/ResourceId'
+        Document:
+          $ref: '#/components/schemas/Document_EPC259-22_V4.0_DS04b'
+        _links:
+          type: object
+          properties:
+            initialSepaRequestToPayUri:
+              $ref: '#/components/schemas/GenericHalLink'
+          required:
+          - initialSepaRequestToPayUri
+    SepaRequestToPayRequestResource:
+      type: object
+      properties:
+        resourceId:
+          $ref: '#/components/schemas/ResourceId'
+        Document:
+          $ref: '#/components/schemas/Document_EPC259-22_V4.0_DS02'
+        callbackUrl:
+          type: string
+          format: uri
+        _links:
+          type: object
+          properties:
+            sepaRequestToPayCancellationRequestUri:
+              $ref: '#/components/schemas/GenericHalLink'
+      required:
+      - callbackUrl
+    AsynchronousSepaRequestToPayResponseResource:
+      type: object
+      properties:
+        resourceId:
+          $ref: '#/components/schemas/ResourceId'
+        AsynchronousSepaRequestToPayResponse:
+          $ref: '#/components/schemas/AsynchronousSepaRequestToPayResponse'
+        _links:
+          type: object
+          properties:
+            initialSepaRequestToPayUri:
+              $ref: '#/components/schemas/GenericHalLink'
+          required:
+          - initialSepaRequestToPayUri
+    SepaRequestToPayCancellationRequestResource:
+      type: object
+      properties:
+        resourceId:
+          $ref: '#/components/schemas/ResourceId'
+        Document:
+          $ref: '#/components/schemas/Document_EPC259-22_V4.0_DS11'
+        callbackUrl:
+          type: string
+          format: uri
+        _links:
+          type: object
+          properties:
+            initialSepaRequestToPayUri:
+              $ref: '#/components/schemas/GenericHalLink'
+          required:
+          - initialSepaRequestToPayUri
+      required:
+      - callbackUrl
+    SepaRequestToPayCancellationResponseResource:
+      type: object
+      properties:
+        resourceId:
+          $ref: '#/components/schemas/ResourceId'
+        SepaRequestToPayCancellationResponse:
+          $ref: '#/components/schemas/SepaRequestToPayCancellationResponse'
+        _links:
+          type: object
+          properties:
+            initialSepaRequestToPayUri:
+              $ref: '#/components/schemas/GenericHalLink'
+          required:
+          - initialSepaRequestToPayUri
+    SepaRequestToPayStatusUpdateRequestResource:
+      type: object
+      properties:
+        resourceId:
+          $ref: '#/components/schemas/ResourceId'
+        Document:
+          $ref: '#/components/schemas/Document_EPC259-22_V4.0_DS15RTP'
+        callbackUrl:
+          type: string
+          format: uri
+        _links:
+          type: object
+          properties:
+            initialSepaRequestToPayUri:
+              $ref: '#/components/schemas/GenericHalLink'
+          required:
+          - initialSepaRequestToPayUri
+      required:
+      - callbackUrl
+    SepaRequestToPayStatusUpdateResponseResource:
+      type: object
+      properties:
+        resourceId:
+          $ref: '#/components/schemas/ResourceId'
+        Document:
+          $ref: '#/components/schemas/Document_EPC259-22_V4.0_DS16RTP'
+        _links:
+          type: object
+          properties:
+            initialSepaRequestToPayUri:
+              $ref: '#/components/schemas/GenericHalLink'
+          required:
+          - initialSepaRequestToPayUri
+    SepaRequestToPayCancellationStatusUpdateRequestResource:
+      type: object
+      properties:
+        resourceId:
+          $ref: '#/components/schemas/ResourceId'
+        Document:
+          $ref: '#/components/schemas/Document_EPC259-22_V4.0_DS15RFC'
+        callbackUrl:
+          type: string
+          format: uri
+        _links:
+          type: object
+          properties:
+            initialSepaRequestToPayUri:
+              $ref: '#/components/schemas/GenericHalLink'
+          required:
+          - initialSepaRequestToPayUri
+      required:
+      - callbackUrl
+    SepaRequestToPayCancellationStatusUpdateResponseResource:
+      type: object
+      properties:
+        resourceId:
+          $ref: '#/components/schemas/ResourceId'
+        Document:
+          $ref: '#/components/schemas/Document_EPC259-22_V4.0_DS16RFC'
+        _links:
+          type: object
+          properties:
+            initialSepaRequestToPayUri:
+              $ref: '#/components/schemas/GenericHalLink'
+          required:
+          - initialSepaRequestToPayUri
+    AsynchronousSepaRequestToPayResponse:
+      oneOf:
+      - $ref: '#/components/schemas/RedirectSepaRequestToPayResponseResource_DS05'
+      - $ref: '#/components/schemas/Document'
+      - $ref: '#/components/schemas/PositiveSepaRequestToPayResponse_DS08P'
+      - $ref: '#/components/schemas/NegativeSepaRequestToPayResponse_DS08N'
+    Document_EPC259-22_V4.0_DS02:
+      type: object
+      properties:
+        CdtrPmtActvtnReq:
+          $ref: '#/components/schemas/CreditorPaymentActivationRequestV10_EPC259-22_V4.0_DS02'
+      required:
+      - CdtrPmtActvtnReq
+    Document_EPC259-22_V4.0_DS04b:
+      type: object
+      properties:
+        CdtrPmtActvtnReqStsRpt:
+          $ref: '#/components/schemas/CreditorPaymentActivationRequestStatusReportV07_EPC259-22_V4.0_DS04b'
+      required:
+      - CdtrPmtActvtnReqStsRpt
+    Document_EPC259-22_V4.0_DS08N:
+      type: object
+      properties:
+        CdtrPmtActvtnReqStsRpt:
+          $ref: '#/components/schemas/CreditorPaymentActivationRequestStatusReportV07_EPC259-22_V4.0_DS08N'
+      required:
+      - CdtrPmtActvtnReqStsRpt
+    Document_EPC259-22_V4.0_DS08P:
+      type: object
+      properties:
+        CdtrPmtActvtnReqStsRpt:
+          $ref: '#/components/schemas/CreditorPaymentActivationRequestStatusReportV07_EPC259-22_V4.0_DS08P'
+      required:
+      - CdtrPmtActvtnReqStsRpt
+    Document_EPC259-22_V4.0_DS11:
+      type: object
+      properties:
+        CstmrPmtCxlReq:
+          $ref: '#/components/schemas/CustomerPaymentCancellationRequestV08_EPC259-22_V4.0_DS11'
+      required:
+      - CstmrPmtCxlReq
+    Document_EPC259-22_V4.0_DS15RFC:
+      type: object
+      properties:
+        CstmrPmtCxlReq:
+          $ref: '#/components/schemas/CustomerPaymentCancellationRequestV08_EPC259-22_V4.0_DS15RFC'
+      required:
+      - CstmrPmtCxlReq
+    Document_EPC259-22_V4.0_DS15RTP:
+      type: object
+      properties:
+        FIToFIPmtStsReq:
+          $ref: '#/components/schemas/FIToFIPaymentStatusRequestV03_EPC259-22_V4.0_DS15RTP'
+      required:
+      - FIToFIPmtStsReq
+    Document_EPC259-22_V4.0_DS16RFC:
+      type: object
+      properties:
+        RsltnOfInvstgtn:
+          $ref: '#/components/schemas/ResolutionOfInvestigationV09_EPC259-22_V4.0_DS16RFC'
+      required:
+      - RsltnOfInvstgtn
+    Document_EPC259-22_V4.0_DS16RTP:
+      type: object
+      properties:
+        CdtrPmtActvtnReqStsRpt:
+          $ref: '#/components/schemas/CreditorPaymentActivationRequestStatusReportV07_EPC259-22_V4.0_DS16RTP'
+      required:
+      - CdtrPmtActvtnReqStsRpt
+    NegativeSepaRequestToPayCancellationResponse:
+      type: object
+      properties:
+        Document:
+          $ref: '#/components/schemas/Document_EPC259-22_V4.0_DS12N'
+    PositiveSepaRequestToPayCancellationResponse:
+      type: object
+      properties:
+        Document:
+          $ref: '#/components/schemas/Document_EPC259-22_V4.0_DS12P'
+    RedirectSepaRequestToPayResponseResource_DS05:
+      type: object
+      properties:
+        resourceId:
+          $ref: '#/components/schemas/ResourceId'
+        Document:
+          $ref: '#/components/schemas/Document_EPC259-22_V4.0_REDIRECT'
+        _links:
+          type: object
+          properties:
+            initialSepaRequestToPayUri:
+              $ref: '#/components/schemas/GenericHalLink'
+          required:
+          - initialSepaRequestToPayUri
+    CreditorPaymentActivationRequestStatusReportV07_EPC259-22_V4.0_DS04b:
+      type: object
+      properties:
+        GrpHdr:
+          $ref: '#/components/schemas/GroupHeader87_EPC259-22_V4.0_DS04b'
+        OrgnlGrpInfAndSts:
+          $ref: '#/components/schemas/OriginalGroupInformation30_EPC259-22_V4.0_DS04b'
+        OrgnlPmtInfAndSts:
+          type: array
+          items:
+            $ref: '#/components/schemas/OriginalPaymentInstruction31_EPC259-22_V4.0_DS04b'
+          maxItems: 2
+      required:
+      - GrpHdr
+      - OrgnlGrpInfAndSts
+    CreditorPaymentActivationRequestStatusReportV07_EPC259-22_V4.0_DS08N:
+      type: object
+      properties:
+        GrpHdr:
+          $ref: '#/components/schemas/GroupHeader87_EPC259-22_V4.0_DS08N'
+        OrgnlGrpInfAndSts:
+          $ref: '#/components/schemas/OriginalGroupInformation30_EPC259-22_V4.0_DS04b'
+        OrgnlPmtInfAndSts:
+          type: array
+          items:
+            $ref: '#/components/schemas/OriginalPaymentInstruction31_EPC259-22_V4.0_DS08N'
+          maxItems: 2
+      required:
+      - GrpHdr
+      - OrgnlGrpInfAndSts
+    CreditorPaymentActivationRequestStatusReportV07_EPC259-22_V4.0_DS08P:
+      type: object
+      properties:
+        GrpHdr:
+          $ref: '#/components/schemas/GroupHeader87_EPC259-22_V4.0_DS08N'
+        OrgnlGrpInfAndSts:
+          $ref: '#/components/schemas/OriginalGroupInformation30_EPC259-22_V4.0_DS04b'
+        OrgnlPmtInfAndSts:
+          $ref: '#/components/schemas/OriginalPaymentInstruction31_EPC259-22_V4.0_DS08P'
+      required:
+      - GrpHdr
+      - OrgnlGrpInfAndSts
+      - OrgnlPmtInfAndSts
+    CreditorPaymentActivationRequestStatusReportV07_EPC259-22_V4.0_DS16RTP:
+      type: object
+      properties:
+        GrpHdr:
+          $ref: '#/components/schemas/GroupHeader87_EPC259-22_V4.0_DS04b'
+        OrgnlGrpInfAndSts:
+          $ref: '#/components/schemas/OriginalGroupInformation29_EPC259-22_V4.0_DS16RTP'
+        OrgnlPmtInfAndSts:
+          type: array
+          items:
+            $ref: '#/components/schemas/OriginalPaymentInstruction31_EPC259-22_V4.0_DS16RTP'
+          maxItems: 2
+      required:
+      - GrpHdr
+      - OrgnlGrpInfAndSts
+    CreditorPaymentActivationRequestV10_EPC259-22_V4.0_DS02:
+      type: object
+      properties:
+        GrpHdr:
+          $ref: '#/components/schemas/GroupHeader105_EPC259-22_V4.0_DS02'
+        PmtInf:
+          type: array
+          items:
+            $ref: '#/components/schemas/PaymentInstruction42_EPC259-22_V4.0_DS02'
+          maxItems: 2
+      required:
+      - GrpHdr
+    CustomerPaymentCancellationRequestV08_EPC259-22_V4.0_DS11:
+      type: object
+      properties:
+        Assgnmt:
+          $ref: '#/components/schemas/CaseAssignment5_EPC259-22_V4.0_DS11'
+        Undrlyg:
+          $ref: '#/components/schemas/UnderlyingTransaction24_EPC259-22_V4.0_DS11'
+      required:
+      - Assgnmt
+      - Undrlyg
+    CustomerPaymentCancellationRequestV08_EPC259-22_V4.0_DS15RFC:
+      type: object
+      properties:
+        Assgnmt:
+          $ref: '#/components/schemas/CaseAssignment5_EPC259-22_V4.0_DS11'
+        Undrlyg:
+          $ref: '#/components/schemas/UnderlyingTransaction24_EPC259-22_V4.0_DS15RFC'
+      required:
+      - Assgnmt
+      - Undrlyg
+    Document:
+      type: object
+      properties:
+        CdtrPmtActvtnReqStsRpt:
+          $ref: '#/components/schemas/CreditorPaymentActivationRequestStatusReportV07'
+      required:
+      - CdtrPmtActvtnReqStsRpt
+    Document_EPC259-22_V4.0_DS12N:
+      type: object
+      properties:
+        RsltnOfInvstgtn:
+          $ref: '#/components/schemas/ResolutionOfInvestigationV09_EPC259-22_V4.0_DS12N'
+      required:
+      - RsltnOfInvstgtn
+    Document_EPC259-22_V4.0_DS12P:
+      type: object
+      properties:
+        RsltnOfInvstgtn:
+          $ref: '#/components/schemas/ResolutionOfInvestigationV09_EPC259-22_V4.0_DS12P'
+      required:
+      - RsltnOfInvstgtn
+    Document_EPC259-22_V4.0_REDIRECT:
+      type: object
+      properties:
+        CdtrPmtActvtnReqStsRpt:
+          $ref: '#/components/schemas/CreditorPaymentActivationRequestStatusReportV07_EPC259-22_V4.0_REDIRECT'
+      required:
+      - CdtrPmtActvtnReqStsRpt
+    FIToFIPaymentStatusRequestV03_EPC259-22_V4.0_DS15RTP:
+      type: object
+      properties:
+        GrpHdr:
+          $ref: '#/components/schemas/GroupHeader91_EPC259-22_V4.0_DS15RTP'
+        TxInf:
+          type: array
+          items:
+            $ref: '#/components/schemas/PaymentTransaction113_EPC259-22_V4.0_DS15RTP'
+      required:
+      - GrpHdr
+    ResolutionOfInvestigationV09_EPC259-22_V4.0_DS16RFC:
+      type: object
+      properties:
+        Assgnmt:
+          $ref: '#/components/schemas/CaseAssignment5_EPC259-22_V4.0_DS11'
+        Sts:
+          $ref: '#/components/schemas/InvestigationStatus5Choice_EPC259-22_V4.0_DS16RFC'
+        CxlDtls:
+          $ref: '#/components/schemas/UnderlyingTransaction22_EPC259-22_V4.0_DS16RFC'
+      required:
+      - Assgnmt
+      - Sts
+      - CxlDtls
+    CaseAssignment5_EPC259-22_V4.0_DS11:
+      type: object
+      properties:
+        Id:
+          $ref: '#/components/schemas/Max35Text'
+        Assgnr:
+          $ref: '#/components/schemas/Party40Choice_EPC259-22_V4.0_DS11'
+        Assgne:
+          $ref: '#/components/schemas/Party40Choice_EPC259-22_V4.0_DS11'
+        CreDtTm:
+          $ref: '#/components/schemas/UtcIsoDateTimeWithMilliseconds'
+      required:
+      - Id
+      - Assgnr
+      - Assgne
+      - CreDtTm
+    CreditorPaymentActivationRequestStatusReportV07:
+      type: object
+      properties:
+        GrpHdr:
+          $ref: '#/components/schemas/GroupHeader87'
+        OrgnlGrpInfAndSts:
+          $ref: '#/components/schemas/OriginalGroupInformation30_EPC259-22_V4.0_DS04b'
+        OrgnlPmtInfAndSts:
+          type: array
+          items:
+            $ref: '#/components/schemas/OriginalPaymentInstruction31'
+          maxItems: 2
+      required:
+      - GrpHdr
+      - OrgnlGrpInfAndSts
+    CreditorPaymentActivationRequestStatusReportV07_EPC259-22_V4.0_REDIRECT:
+      type: object
+      properties:
+        GrpHdr:
+          $ref: '#/components/schemas/GroupHeader87_EPC259-22_V4.0_DS04b'
+        OrgnlGrpInfAndSts:
+          $ref: '#/components/schemas/OriginalGroupInformation30_EPC259-22_V4.0_DS04b'
+        OrgnlPmtInfAndSts:
+          type: array
+          items:
+            $ref: '#/components/schemas/OriginalPaymentInstruction31_EPC259-22_V4.0_REDIRECT'
+          maxItems: 2
+      required:
+      - GrpHdr
+      - OrgnlGrpInfAndSts
+    GroupHeader105_EPC259-22_V4.0_DS02:
+      type: object
+      properties:
+        MsgId:
+          $ref: '#/components/schemas/Max35Text'
+        CreDtTm:
+          $ref: '#/components/schemas/UtcIsoDateTimeWithMilliseconds'
+        NbOfTxs:
+          $ref: '#/components/schemas/Max15NumericText'
+        InitgPty:
+          $ref: '#/components/schemas/PartyIdentification135_EPC259-22_V4.0_DS02'
+      required:
+      - MsgId
+      - CreDtTm
+      - NbOfTxs
+      - InitgPty
+    GroupHeader87_EPC259-22_V4.0_DS04b:
+      type: object
+      properties:
+        MsgId:
+          $ref: '#/components/schemas/Max35Text'
+        CreDtTm:
+          $ref: '#/components/schemas/UtcIsoDateTimeWithMilliseconds'
+        InitgPty:
+          $ref: '#/components/schemas/PartyIdentification135_EPC259-22_V4.0_DS04b'
+      required:
+      - MsgId
+      - CreDtTm
+      - InitgPty
+    GroupHeader87_EPC259-22_V4.0_DS08N:
+      type: object
+      properties:
+        MsgId:
+          $ref: '#/components/schemas/Max35Text'
+        CreDtTm:
+          $ref: '#/components/schemas/UtcIsoDateTimeWithMilliseconds'
+        InitgPty:
+          $ref: '#/components/schemas/PartyIdentification135_EPC259-22_V4.0_DS08N'
+      required:
+      - MsgId
+      - CreDtTm
+      - InitgPty
+    GroupHeader91_EPC259-22_V4.0_DS15RTP:
+      type: object
+      properties:
+        MsgId:
+          $ref: '#/components/schemas/Max35Text'
+        CreDtTm:
+          $ref: '#/components/schemas/UtcIsoDateTimeWithMilliseconds'
+        InstgAgt:
+          $ref: '#/components/schemas/BranchAndFinancialInstitutionIdentification6_EPC259-22_V4.0_DS15RTP'
+      required:
+      - MsgId
+      - CreDtTm
+      - InstgAgt
+    InvestigationStatus5Choice_EPC259-22_V4.0_DS16RFC:
+      oneOf:
+      - $ref: '#/components/schemas/YesNoIndicator_Wrapper'
+    OriginalGroupInformation30_EPC259-22_V4.0_DS04b:
+      type: object
+      properties:
+        OrgnlMsgId:
+          $ref: '#/components/schemas/Max35Text'
+        OrgnlMsgNmId:
+          $ref: '#/components/schemas/Max35Text_OrgnlMsgNmId'
+        OrgnlCreDtTm:
+          $ref: '#/components/schemas/UtcIsoDateTimeWithMilliseconds'
+      required:
+      - OrgnlMsgId
+      - OrgnlMsgNmId
+      - OrgnlCreDtTm'
+    OriginalPaymentInstruction31_EPC259-22_V4.0_DS04b:
+      type: object
+      properties:
+        OrgnlPmtInfId:
+          $ref: '#/components/schemas/Max35Text'
+        TxInfAndSts:
+          $ref: '#/components/schemas/PaymentTransaction104_EPC259-22_V4.0_DS04b'
+      required:
+      - OrgnlPmtInfId
+      - TxInfAndSts
+    OriginalPaymentInstruction31_EPC259-22_V4.0_DS08N:
+      type: object
+      properties:
+        OrgnlPmtInfId:
+          $ref: '#/components/schemas/Max35Text'
+        TxInfAndSts:
+          $ref: '#/components/schemas/PaymentTransaction104_EPC259-22_V4.0_DS08N'
+      required:
+      - OrgnlPmtInfId
+      - TxInfAndSts
+    OriginalPaymentInstruction31_EPC259-22_V4.0_DS08P:
+      type: object
+      properties:
+        OrgnlPmtInfId:
+          $ref: '#/components/schemas/Max35Text'
+        TxInfAndSts:
+          type: array
+          items:
+            $ref: '#/components/schemas/PaymentTransaction104_EPC259-22_V4.0_DS08P'
+      required:
+      - OrgnlPmtInfId
+    OriginalPaymentInstruction31_EPC259-22_V4.0_DS16RTP:
+      type: object
+      properties:
+        OrgnlPmtInfId:
+          $ref: '#/components/schemas/Max35Text'
+        TxInfAndSts:
+          type: array
+          items:
+            $ref: '#/components/schemas/PaymentTransaction104_EPC259-22_V4.0_DS16RTP'
+      required:
+      - OrgnlPmtInfId
+    PaymentInstruction42_EPC259-22_V4.0_DS02:
+      type: object
+      properties:
+        PmtInfId:
+          $ref: '#/components/schemas/Max35Text'
+        PmtMtd:
+          $ref: '#/components/schemas/PaymentMethod7Code'
+        ReqdAdvcTp:
+          $ref: '#/components/schemas/AdviceType1'
+        ReqdExctnDt:
+          $ref: '#/components/schemas/DateAndDateTime2Choice_EPC259-22_V4.0_DS02'
+        XpryDt:
+          $ref: '#/components/schemas/DateAndDateTime2Choice_EPC259-22_V4.0_DS02'
+        Dbtr:
+          $ref: '#/components/schemas/PartyIdentification135_EPC259-22_V4.0_DS02_2'
+        DbtrAcct:
+          $ref: '#/components/schemas/CashAccount40_EPC259-22_V4.0_DS02'
+        DbtrAgt:
+          $ref: '#/components/schemas/BranchAndFinancialInstitutionIdentification6_EPC259-22_V4.0_DS02'
+        CdtTrfTx:
+          type: array
+          items:
+            $ref: '#/components/schemas/CreditTransferTransaction57_EPC259-22_V4.0_DS02'
+      required:
+      - PmtInfId
+      - PmtMtd
+      - XpryDt
+      - Dbtr
+      - DbtrAgt
+    PaymentTransaction113_EPC259-22_V4.0_DS15RTP:
+      type: object
+      properties:
+        StsReqId:
+          $ref: '#/components/schemas/Max35Text'
+        OrgnlGrpInf:
+          $ref: '#/components/schemas/OriginalGroupInformation29_EPC259-22_V4.0_DS15RTP'
+        OrgnlInstrId:
+          $ref: '#/components/schemas/Max35Text'
+        OrgnlEndToEndId:
+          $ref: '#/components/schemas/Max35Text'
+        OrgnlTxId:
+          $ref: '#/components/schemas/Max35Text'
+        OrgnlTxRef:
+          $ref: '#/components/schemas/OriginalTransactionReference28_EPC259-22_V4.0_DS15RTP'
+      required:
+      - StsReqId
+      - OrgnlGrpInf
+      - OrgnlInstrId
+      - OrgnlEndToEndId
+      - OrgnlTxRef
+    ResolutionOfInvestigationV09_EPC259-22_V4.0_DS12N:
+      type: object
+      properties:
+        Assgnmt:
+          $ref: '#/components/schemas/CaseAssignment5_EPC259-22_V4.0_DS11'
+        Sts:
+          $ref: '#/components/schemas/InvestigationStatus5Choice_EPC259-22_V4.0_DS12N'
+        CxlDtls:
+          $ref: '#/components/schemas/UnderlyingTransaction22_EPC259-22_V4.0_DS12N'
+      required:
+      - Assgnmt
+      - Sts
+      - CxlDtls
+    ResolutionOfInvestigationV09_EPC259-22_V4.0_DS12P:
+      type: object
+      properties:
+        Assgnmt:
+          $ref: '#/components/schemas/CaseAssignment5_EPC259-22_V4.0_DS11'
+        Sts:
+          $ref: '#/components/schemas/InvestigationStatus5Choice_EPC259-22_V4.0_DS12P'
+        CxlDtls:
+          $ref: '#/components/schemas/UnderlyingTransaction22_EPC259-22_V4.0_DS12P'
+      required:
+      - Assgnmt
+      - Sts
+      - CxlDtls
+    UnderlyingTransaction22_EPC259-22_V4.0_DS16RFC:
+      type: object
+      properties:
+        OrgnlPmtInfAndSts:
+          type: array
+          items:
+            $ref: '#/components/schemas/OriginalPaymentInstruction30_EPC259-22_V4.0_DS16RFC'
+          maxItems: 2
+        TxInfAndSts:
+          type: array
+          items:
+            $ref: '#/components/schemas/PaymentTransaction102_EPC259-22_V4.0_DS16RFC'
+    UnderlyingTransaction24_EPC259-22_V4.0_DS11:
+      type: object
+      properties:
+        OrgnlPmtInfAndCxl:
+          type: array
+          items:
+            $ref: '#/components/schemas/OriginalPaymentInstruction34_EPC259-22_V4.0_DS11'
+          maxItems: 2
+    UnderlyingTransaction24_EPC259-22_V4.0_DS15RFC:
+      type: object
+      properties:
+        OrgnlPmtInfAndCxl:
+          type: array
+          items:
+            $ref: '#/components/schemas/OriginalPaymentInstruction34_EPC259-22_V4.0_DS15RFC'
+          maxItems: 2
+    AdviceType1:
+      type: object
+      properties:
+        CdtAdvc:
+          $ref: '#/components/schemas/AdviceType1Choice'
+        DbtAdvc:
+          $ref: '#/components/schemas/AdviceType1Choice'
+    BranchAndFinancialInstitutionIdentification6_EPC259-22_V4.0_DS02:
+      type: object
+      properties:
+        FinInstnId:
+          $ref: '#/components/schemas/FinancialInstitutionIdentification18_EPC259-22_V4.0_DS02'
+      required:
+      - FinInstnId
+    BranchAndFinancialInstitutionIdentification6_EPC259-22_V4.0_DS15RTP:
+      type: object
+      properties:
+        FinInstnId:
+          $ref: '#/components/schemas/FinancialInstitutionIdentification18_EPC259-22_V4.0_DS15RTP'
+      required:
+      - FinInstnId
+    CashAccount40_EPC259-22_V4.0_DS02:
+      type: object
+      properties:
+        Id:
+          $ref: '#/components/schemas/AccountIdentification4Choice_EPC259-22_V4.0_DS02'
+        Nm:
+          $ref: '#/components/schemas/Max70Text'
+        Prxy:
+          $ref: '#/components/schemas/ProxyAccountIdentification1_EPC259-22_V4.0_DS02'
+    CreditTransferTransaction57_EPC259-22_V4.0_DS02:
+      type: object
+      properties:
+        PmtId:
+          $ref: '#/components/schemas/PaymentIdentification6_EPC259-22_V4.0_DS02'
+        PmtTpInf:
+          $ref: '#/components/schemas/PaymentTypeInformation26_EPC259-22_V4.0_DS02'
+        PmtCond:
+          $ref: '#/components/schemas/PaymentCondition1_EPC259-22_V4.0_DS02'
+        ReqdExctnDt:
+          $ref: '#/components/schemas/DateAndDateTime2Choice_EPC259-22_V4.0_DS02'
+        Amt:
+          $ref: '#/components/schemas/AmountType4Choice_EPC259-22_V4.0_DS02'
+        ChrgBr:
+          $ref: '#/components/schemas/ChargeBearerType1Code'
+        CdtrAgt:
+          $ref: '#/components/schemas/BranchAndFinancialInstitutionIdentification6_EPC259-22_V4.0_DS02'
+        Cdtr:
+          $ref: '#/components/schemas/PartyIdentification135_EPC259-22_V4.0_DS02_3'
+        CdtrAcct:
+          $ref: '#/components/schemas/CashAccount40_EPC259-22_V4.0_DS02_2'
+        UltmtCdtr:
+          $ref: '#/components/schemas/PartyIdentification135_EPC259-22_V4.0_DS02_4'
+        InstrForCdtrAgt:
+          type: array
+          items:
+            $ref: '#/components/schemas/InstructionForCreditorAgent3_EPC259-22_V4.0_DS02'
+          maxItems: 5
+        Purp:
+          $ref: '#/components/schemas/Purpose2Choice_EPC259-22_V4.0_DS02'
+        RltdRmtInf:
+          $ref: '#/components/schemas/RemittanceLocation7_EPC259-22_V4.0_DS02'
+        RmtInf:
+          $ref: '#/components/schemas/RemittanceInformation21_EPC259-22_V4.0_DS02'
+        NclsdFile:
+          type: array
+          items:
+            $ref: '#/components/schemas/Document12_EPC259-22_V4.0_DS02'
+      required:
+      - PmtId
+      - PmtTpInf
+      - Amt
+      - ChrgBr
+      - CdtrAgt
+      - Cdtr
+      - CdtrAcct
+    DateAndDateTime2Choice_EPC259-22_V4.0_DS02:
+      oneOf:
+      - $ref: '#/components/schemas/ISODate_Wrapper'
+      - $ref: '#/components/schemas/ISODateTime_Wrapper'
+    GroupHeader87:
+      type: object
+      properties:
+        MsgId:
+          $ref: '#/components/schemas/Max35Text'
+        CreDtTm:
+          $ref: '#/components/schemas/UtcIsoDateTimeWithMilliseconds'
+        InitgPty:
+          $ref: '#/components/schemas/PartyIdentification135'
+      required:
+      - MsgId
+      - CreDtTm
+      - InitgPty
+    ISODateTime:
+      type: string
+    InvestigationStatus5Choice_EPC259-22_V4.0_DS12N:
+      oneOf:
+      - $ref: '#/components/schemas/ExternalInvestigationExecutionConfirmation1Code_Wrapper'
+    InvestigationStatus5Choice_EPC259-22_V4.0_DS12P:
+      oneOf:
+      - $ref: '#/components/schemas/ExternalInvestigationExecutionConfirmation1Code_II_Wrapper'
+    Max15NumericText:
+      pattern: '[0-9]{1,15}'
+      type: string
+    Max35Text:
+      maxLength: 35
+      minLength: 1
+      type: string
+    Max35Text_OrgnlMsgNmId:
+      type: string
+      maxLength: 35
+      minLength: 1
+      description: |
+        SEPA Usage Rule:
+        - Must begin with ‘pain.013’. The addition of a variant number and version number is optional.
+    Max35Text_OrgnlMsgNmId_DS15RFC:
+      type: string
+      maxLength: 35
+      minLength: 1
+      description: |
+        SEPA Usage Rule:
+        - Must begin with ‘camt.055’. The addition of a variant number and version number is optional.
+    Max35Text_OrgnlMsgNmId_DS16RTP:
+      type: string
+      maxLength: 35
+      minLength: 1
+      description: |
+        SEPA Usage Rule:
+        - Must begin with ‘pacs.028’. The addition of a variant number and version number is optional.
+    OriginalGroupInformation29_EPC259-22_V4.0_DS15RFC:
+      type: object
+      properties:
+        OrgnlMsgId:
+          $ref: '#/components/schemas/Max35Text'
+        OrgnlMsgNmId:
+          $ref: '#/components/schemas/Max35Text_OrgnlMsgNmId_DS15RFC'
+        OrgnlCreDtTm:
+          $ref: '#/components/schemas/UtcIsoDateTimeWithMilliseconds'
+      required:
+      - OrgnlMsgId
+      - OrgnlMsgNmId
+      - OrgnlCreDtTm
+    OriginalGroupInformation29_EPC259-22_V4.0_DS15RTP:
+      type: object
+      properties:
+        OrgnlMsgId:
+          $ref: '#/components/schemas/Max35Text'
+        OrgnlMsgNmId:
+          $ref: '#/components/schemas/Max35Text_OrgnlMsgNmId'
+        OrgnlCreDtTm:
+          $ref: '#/components/schemas/UtcIsoDateTimeWithMilliseconds'
+      required:
+      - OrgnlMsgId
+      - OrgnlMsgNmId
+      - OrgnlCreDtTm
+    OriginalGroupInformation29_EPC259-22_V4.0_DS16RTP:
+      type: object
+      properties:
+        OrgnlMsgId:
+          $ref: '#/components/schemas/Max35Text'
+        OrgnlMsgNmId:
+          $ref: '#/components/schemas/Max35Text_OrgnlMsgNmId_DS16RTP'
+        OrgnlCreDtTm:
+          $ref: '#/components/schemas/UtcIsoDateTimeWithMilliseconds'
+      required:
+      - OrgnlMsgId
+      - OrgnlMsgNmId
+      - OrgnlCreDtTm
+    OriginalPaymentInstruction30_EPC259-22_V4.0_DS16RFC:
+      type: object
+      properties:
+        OrgnlPmtInfId:
+          $ref: '#/components/schemas/Max35Text'
+        TxInfAndSts:
+          type: array
+          items:
+            $ref: '#/components/schemas/PaymentTransaction103_EPC259-22_V4.0_DS16RFC'
+      required:
+      - OrgnlPmtInfId
+    OriginalPaymentInstruction31:
+      type: object
+      properties:
+        OrgnlPmtInfId:
+          $ref: '#/components/schemas/Max35Text'
+        TxInfAndSts:
+          $ref: '#/components/schemas/PaymentTransaction104'
+      required:
+      - OrgnlPmtInfId
+      - TxInfAndSts
+    OriginalPaymentInstruction31_EPC259-22_V4.0_REDIRECT:
+      type: object
+      properties:
+        OrgnlPmtInfId:
+          $ref: '#/components/schemas/Max35Text'
+        TxInfAndSts:
+          type: array
+          items:
+            $ref: '#/components/schemas/PaymentTransaction104_EPC259-22_V4.0_REDIRECT'
+      required:
+      - OrgnlPmtInfId
+    OriginalPaymentInstruction34_EPC259-22_V4.0_DS11:
+      type: object
+      properties:
+        PmtCxlId:
+          $ref: '#/components/schemas/Max35Text'
+        OrgnlPmtInfId:
+          $ref: '#/components/schemas/Max35Text'
+        OrgnlGrpInf:
+          $ref: '#/components/schemas/OriginalGroupInformation29_EPC259-22_V4.0_DS15RTP'
+        TxInf:
+          type: array
+          items:
+            $ref: '#/components/schemas/PaymentTransaction109_EPC259-22_V4.0_DS11'
+      required:
+      - OrgnlPmtInfId
+    OriginalPaymentInstruction34_EPC259-22_V4.0_DS15RFC:
+      type: object
+      properties:
+        PmtCxlId:
+          $ref: '#/components/schemas/Max35Text'
+        OrgnlPmtInfId:
+          $ref: '#/components/schemas/Max35Text'
+        OrgnlGrpInf:
+          $ref: '#/components/schemas/OriginalGroupInformation29_EPC259-22_V4.0_DS15RFC'
+        TxInf:
+          type: array
+          items:
+            $ref: '#/components/schemas/PaymentTransaction109_EPC259-22_V4.0_DS15RFC'
+      required:
+      - OrgnlPmtInfId
+    OriginalTransactionReference28_EPC259-22_V4.0_DS15RTP:
+      type: object
+      properties:
+        Amt:
+          $ref: '#/components/schemas/AmountType4Choice_EPC259-22_V4.0_DS02'
+        ReqdExctnDt:
+          $ref: '#/components/schemas/DateAndDateTime2Choice_EPC259-22_V4.0_DS02'
+        PmtTpInf:
+          $ref: '#/components/schemas/PaymentTypeInformation27_EPC259-22_V4.0_DS15RTP'
+        RmtInf:
+          $ref: '#/components/schemas/RemittanceInformation16_EPC259-22_V4.0_DS15RTP'
+        DbtrAgt:
+          $ref: '#/components/schemas/BranchAndFinancialInstitutionIdentification6_EPC259-22_V4.0_DS02'
+        CdtrAgt:
+          $ref: '#/components/schemas/BranchAndFinancialInstitutionIdentification6_EPC259-22_V4.0_DS02'
+        Cdtr:
+          $ref: '#/components/schemas/Party40Choice_EPC259-22_V4.0_DS15RTP'
+        CdtrAcct:
+          $ref: '#/components/schemas/CashAccount38'
+      required:
+      - Amt
+      - ReqdExctnDt
+      - PmtTpInf
+      - RmtInf
+      - DbtrAgt
+      - CdtrAgt
+      - Cdtr
+      - CdtrAcct
+    Party40Choice_EPC259-22_V4.0_DS11:
+      oneOf:
+      - $ref: '#/components/schemas/PartyIdentification135_EPC259-22_V4.0_DS04b_Wrapper'
+      - $ref: '#/components/schemas/BranchAndFinancialInstitutionIdentification6_EPC259-22_V4.0_DS02_Wrapper'
+    PartyIdentification135_EPC259-22_V4.0_DS02:
+      type: object
+      properties:
+        Nm:
+          $ref: '#/components/schemas/Max140Text_EPC259-22_V4.0_DS02'
+        Id:
+          $ref: '#/components/schemas/Party38Choice'
+    PartyIdentification135_EPC259-22_V4.0_DS02_2:
+      type: object
+      properties:
+        Nm:
+          $ref: '#/components/schemas/Max140Text_CreditorName_DS02'
+        PstlAdr:
+          $ref: '#/components/schemas/PostalAddress24_EPC259-22_V4.0_DS02'
+        Id:
+          $ref: '#/components/schemas/Party38Choice_EPC259-22_V4.0_DS02'
+    PartyIdentification135_EPC259-22_V4.0_DS04b:
+      type: object
+      properties:
+        Id:
+          $ref: '#/components/schemas/Party38Choice_EPC259-22_V4.0_DS04b'
+      required:
+      - Id
+    PartyIdentification135_EPC259-22_V4.0_DS08N:
+      type: object
+      properties:
+        Id:
+          $ref: '#/components/schemas/Party38Choice_II'
+    PaymentMethod7Code:
+      enum:
+      - TRF
+      type: string
+    PaymentTransaction102_EPC259-22_V4.0_DS16RFC:
+      type: object
+      properties:
+        CxlStsId:
+          $ref: '#/components/schemas/Max35Text'
+        OrgnlGrpInf:
+          $ref: '#/components/schemas/OriginalGroupInformation29_EPC259-22_V4.0_DS15RFC'
+        OrgnlInstrId:
+          $ref: '#/components/schemas/Max35Text'
+        OrgnlEndToEndId:
+          $ref: '#/components/schemas/Max35Text'
+        OrgnlTxId:
+          $ref: '#/components/schemas/Max35Text'
+        CxlStsRsnInf:
+          $ref: '#/components/schemas/CancellationStatusReason4_EPC259-22_V4.0_DS16RFC'
+        RsltnRltdInf:
+          $ref: '#/components/schemas/ResolutionData1_EPC259-22_V4.0_DS16RFC'
+        OrgnlTxRef:
+          $ref: '#/components/schemas/OriginalTransactionReference28_EPC259-22_V4.0_DS16RFC'
+      required:
+      - CxlStsId
+      - OrgnlGrpInf
+      - OrgnlInstrId
+      - OrgnlEndToEndId
+      - CxlStsRsnInf
+      - OrgnlTxRef
+    PaymentTransaction104_EPC259-22_V4.0_DS04b:
+      type: object
+      properties:
+        StsId:
+          $ref: '#/components/schemas/Max35Text'
+        OrgnlInstrId:
+          $ref: '#/components/schemas/Max35Text'
+        OrgnlEndToEndId:
+          $ref: '#/components/schemas/Max35Text'
+        TxSts:
+          $ref: '#/components/schemas/ExternalPaymentTransactionStatus1Code'
+        StsRsnInf:
+          $ref: '#/components/schemas/StatusReasonInformation12_EPC259-22_V4.0_DS04b'
+        ChrgsInf:
+          $ref: '#/components/schemas/Charges7_EPC259-22_V4.0_DS04b'
+        OrgnlTxRef:
+          $ref: '#/components/schemas/OriginalTransactionReference29_EPC259-22_V4.0_DS04b'
+      required:
+      - StsId
+      - OrgnlInstrId
+      - OrgnlEndToEndId
+      - TxSts
+      - StsRsnInf
+      - OrgnlTxRef
+    PaymentTransaction104_EPC259-22_V4.0_DS08N:
+      type: object
+      properties:
+        StsId:
+          $ref: '#/components/schemas/Max35Text'
+        OrgnlInstrId:
+          $ref: '#/components/schemas/Max35Text'
+        OrgnlEndToEndId:
+          $ref: '#/components/schemas/Max35Text'
+        TxSts:
+          $ref: '#/components/schemas/ExternalPaymentTransactionStatus1Code'
+        StsRsnInf:
+          $ref: '#/components/schemas/StatusReasonInformation12_EPC259-22_V4.0_DS08N'
+        ChrgsInf:
+          $ref: '#/components/schemas/Charges7_EPC259-22_V4.0_DS04b'
+        DbtrDcsnDtTm:
+          $ref: '#/components/schemas/UtcIsoDateTimeWithMilliseconds'
+        OrgnlTxRef:
+          $ref: '#/components/schemas/OriginalTransactionReference29_EPC259-22_V4.0_DS08N'
+      required:
+      - OrgnlInstrId
+      - OrgnlEndToEndId
+      - TxSts
+      - StsRsnInf
+      - DbtrDcsnDtTm
+      - OrgnlTxRef
+    PaymentTransaction104_EPC259-22_V4.0_DS08P:
+      type: object
+      properties:
+        StsId:
+          $ref: '#/components/schemas/Max35Text'
+        OrgnlInstrId:
+          $ref: '#/components/schemas/Max35Text'
+        OrgnlEndToEndId:
+          $ref: '#/components/schemas/Max35Text'
+        TxSts:
+          $ref: '#/components/schemas/ExternalPaymentTransactionStatus1Code_IV'
+        StsRsnInf:
+          $ref: '#/components/schemas/StatusReasonInformation12_EPC259-22_V4.0_DS08P'
+        PmtCondSts:
+          $ref: '#/components/schemas/PaymentConditionStatus1_EPC259-22_V4.0_DS08P'
+        ChrgsInf:
+          $ref: '#/components/schemas/Charges7_EPC259-22_V4.0_DS04b'
+        DbtrDcsnDtTm:
+          $ref: '#/components/schemas/UtcIsoDateTimeWithMilliseconds'
+        AccptncDtTm:
+          $ref: '#/components/schemas/UtcIsoDateTimeWithMilliseconds'
+        OrgnlTxRef:
+          $ref: '#/components/schemas/OriginalTransactionReference29_EPC259-22_V4.0_DS08P'
+      required:
+      - OrgnlInstrId
+      - OrgnlEndToEndId
+      - TxSts
+      - StsRsnInf
+      - DbtrDcsnDtTm
+      - OrgnlTxRef
+    PaymentTransaction104_EPC259-22_V4.0_DS16RTP:
+      type: object
+      properties:
+        StsId:
+          $ref: '#/components/schemas/Max35Text'
+        OrgnlInstrId:
+          $ref: '#/components/schemas/Max35Text'
+        OrgnlEndToEndId:
+          $ref: '#/components/schemas/Max35Text'
+        StsRsnInf:
+          $ref: '#/components/schemas/StatusReasonInformation12_EPC259-22_V4.0_DS16RTP'
+        ChrgsInf:
+          $ref: '#/components/schemas/Charges7_EPC259-22_V4.0_DS04b'
+        OrgnlTxRef:
+          $ref: '#/components/schemas/OriginalTransactionReference29_EPC259-22_V4.0_DS16RTP'
+      required:
+      - StsId
+      - OrgnlInstrId
+      - OrgnlEndToEndId
+      - StsRsnInf
+      - OrgnlTxRef
+    UnderlyingTransaction22_EPC259-22_V4.0_DS12N:
+      type: object
+      properties:
+        OrgnlPmtInfAndSts:
+          type: array
+          items:
+            $ref: '#/components/schemas/OriginalPaymentInstruction30_EPC259-22_V4.0_DS12N'
+          maxItems: 2
+        TxInfAndSts:
+          $ref: '#/components/schemas/PaymentTransaction102_EPC259-22_V4.0_DS12N'
+      required:
+      - TxInfAndSts
+    UnderlyingTransaction22_EPC259-22_V4.0_DS12P:
+      type: object
+      properties:
+        OrgnlPmtInfAndSts:
+          type: array
+          items:
+            $ref: '#/components/schemas/OriginalPaymentInstruction30_EPC259-22_V4.0_DS16RFC'
+          maxItems: 2
+        TxInfAndSts:
+          type: array
+          items:
+            $ref: '#/components/schemas/PaymentTransaction102_EPC259-22_V4.0_DS12P'
+    YesNoIndicator:
+      type: boolean
+    AccountIdentification4Choice_EPC259-22_V4.0_DS02:
+      oneOf:
+      - $ref: '#/components/schemas/IBAN2007Identifier_Wrapper'
+      - $ref: '#/components/schemas/GenericAccountIdentification1_EPC259-22_V4.0_DS02_Wrapper'
+    AdviceType1Choice:
+      oneOf:
+      - $ref: '#/components/schemas/AdviceType1Code_Wrapper'
+      - $ref: '#/components/schemas/Max35Text_Wrapper'
+    AmountType4Choice_EPC259-22_V4.0_DS02:
+      oneOf:
+      - $ref: '#/components/schemas/ActiveOrHistoricCurrencyAndAmount_EPC259-22_V4.0_DS02_Wrapper'
+    CancellationStatusReason4_EPC259-22_V4.0_DS16RFC:
+      type: object
+      properties:
+        Orgtr:
+          $ref: '#/components/schemas/PartyIdentification135_EPC259-22_V4.0_DS04b'
+        Rsn:
+          $ref: '#/components/schemas/CancellationStatusReason3Choice_EPC259-22_V4.0_DS16RFC'
+        AddtlInf:
+          type: array
+          items:
+            $ref: '#/components/schemas/Max105Text'
+          maxItems: 4
+      required:
+      - Orgtr
+      - Rsn
+    CashAccount38:
+      type: object
+      properties:
+        Id:
+          $ref: '#/components/schemas/AccountIdentification4Choice'
+      required:
+      - Id
+    CashAccount40_EPC259-22_V4.0_DS02_2:
+      type: object
+      properties:
+        Id:
+          $ref: '#/components/schemas/AccountIdentification4Choice'
+    ChargeBearerType1Code:
+      type: string
+      description: |
+        SEPA Usage Rule: Code restrictions removed V4.0 (previously limited to SLEV).
+    Charges7_EPC259-22_V4.0_DS04b:
+      type: object
+      properties:
+        Amt:
+          $ref: '#/components/schemas/ActiveOrHistoricCurrencyAndAmount_EPC259-22_V4.0_DS04b'
+        Agt:
+          $ref: '#/components/schemas/BranchAndFinancialInstitutionIdentification6_EPC259-22_V4.0_DS02'
+      required:
+      - Amt
+      - Agt
+    Document12_EPC259-22_V4.0_DS02:
+      type: object
+      properties:
+        Tp:
+          $ref: '#/components/schemas/DocumentType1Choice_EPC259-22_V4.0_DS02'
+        Id:
+          $ref: '#/components/schemas/Max35Text'
+        IsseDt:
+          $ref: '#/components/schemas/DateAndDateTime2Choice_EPC259-22_V4.0_DS02'
+        Nm:
+          $ref: '#/components/schemas/Max140Text'
+        Frmt:
+          $ref: '#/components/schemas/DocumentFormat1Choice_EPC259-22_V4.0_DS02'
+        DgtlSgntr:
+          $ref: '#/components/schemas/PartyAndSignature3'
+        Nclsr:
+          $ref: '#/components/schemas/Max10MbBinary'
+      required:
+      - Tp
+      - Id
+      - IsseDt
+      - Frmt
+      - Nclsr
+    ExternalInvestigationExecutionConfirmation1Code:
+      maxLength: 4
+      minLength: 1
+      enum:
+      - RJCR
+      type: string
+    ExternalInvestigationExecutionConfirmation1Code_II:
+      maxLength: 4
+      minLength: 1
+      enum:
+      - CNCL
+      type: string
+    ExternalPaymentTransactionStatus1Code:
+      maxLength: 4
+      minLength: 1
+      enum:
+      - RJCT
+      type: string
+    ExternalPaymentTransactionStatus1Code_II:
+      maxLength: 4
+      minLength: 1
+      enum:
+      - ACTC
+      type: string
+    ExternalPaymentTransactionStatus1Code_IV:
+      maxLength: 4
+      minLength: 1
+      enum:
+      - ACCP
+      - ACWC
+      type: string
+    FinancialInstitutionIdentification18_EPC259-22_V4.0_DS02:
+      type: object
+      properties:
+        BICFI:
+          $ref: '#/components/schemas/BICFIDec2014Identifier'
+        LEI:
+          $ref: '#/components/schemas/LEIIdentifier'
+        Othr:
+          $ref: '#/components/schemas/GenericFinancialIdentification1'
+    FinancialInstitutionIdentification18_EPC259-22_V4.0_DS15RTP:
+      type: object
+      properties:
+        BICFI:
+          $ref: '#/components/schemas/BICFIDec2014Identifier'
+        LEI:
+          $ref: '#/components/schemas/LEIIdentifier'
+        Nm:
+          $ref: '#/components/schemas/Max140Text_EPC259-22_V4.0_DS02'
+        Othr:
+          $ref: '#/components/schemas/GenericFinancialIdentification1'
+    ISODate:
+      type: string
+    InstructionForCreditorAgent3_EPC259-22_V4.0_DS02:
+      type: object
+      properties:
+        InstrInf:
+          allOf:
+            - $ref: '#/components/schemas/Max140Text'
+            - description: |
+                SEPA Rulebook Reference:
+                - AT-B037 Activation Reference (Mandatory if provided in DS-01)
+                SEPA Usage Rule:
+                - One occurrence starting with "ATB037/" followed by the activation reference.
+      required:
+      - InstrInf
+    Max140Text_CreditorName_DS02:
+      type: string
+      maxLength: 70
+      minLength: 1
+      description: |
+        SEPA Rulebook references:
+        - AT-E001 Name of the Payee
+        - AT-E002 Trade Name of the Payee
+        SEPA Usage Rules:
+        - If a legal name as well as commercial/trade name are provided for a legal person, then the commercial/trade name is to be provided under 'Creditor/Identification'.
+        - For a natural person, the first and last name must be provided.
+    Max140Text_CreditorName_DS11:
+      type: string
+      maxLength: 70
+      minLength: 1
+      description: |
+        SEPA Rulebook references:
+        - AT-E001 Name of the Payee
+        SEPA Usage Rule:
+        - Only allowed if the Payee is the Originator of the RfC, and then mandatory.
+        - For a natural person, the first and last name must be provided.
+        - 'Name’ is limited to 70 characters in length.
+    Max140Text_CreditorName_DSXX:
+      type: string
+      maxLength: 70
+      minLength: 1
+      description: |
+        SEPA Rulebook references:
+        - AT-E001 Name of the Payee
+        - AT-E002 Trade Name of the Payee
+        SEPA Usage Rule:
+        - For a natural person, the first and last name must be provided.
+    Max140Text_CreditorName_DSXX_2:
+      type: string
+      maxLength: 70
+      minLength: 1
+      description: |
+        SEPA Rulebook references:
+        - AT-E001 Name of the Payee
+        - AT-E002 Trade Name of the Payee
+    Max140Text_EPC259-22_V4.0_DS02:
+      maxLength: 70
+      minLength: 1
+      type: string
+    Max70Text:
+      maxLength: 70
+      minLength: 1
+      type: string
+    OriginalPaymentInstruction30_EPC259-22_V4.0_DS12N:
+      type: object
+      properties:
+        OrgnlPmtInfId:
+          $ref: '#/components/schemas/Max35Text'
+        TxInfAndSts:
+          $ref: '#/components/schemas/PaymentTransaction103_EPC259-22_V4.0_DS16RFC'
+      required:
+      - OrgnlPmtInfId
+      - TxInfAndSts
+    OriginalTransactionReference28_EPC259-22_V4.0_DS16RFC:
+      type: object
+      properties:
+        Amt:
+          $ref: '#/components/schemas/AmountType4Choice_EPC259-22_V4.0_DS02'
+        ReqdExctnDt:
+          $ref: '#/components/schemas/DateAndDateTime2Choice_EPC259-22_V4.0_DS02'
+        PmtTpInf:
+          $ref: '#/components/schemas/PaymentTypeInformation27_EPC259-22_V4.0_DS15RTP'
+        RmtInf:
+          $ref: '#/components/schemas/RemittanceInformation16_EPC259-22_V4.0_DS04b'
+        DbtrAgt:
+          $ref: '#/components/schemas/BranchAndFinancialInstitutionIdentification6_EPC259-22_V4.0_DS02'
+        CdtrAgt:
+          $ref: '#/components/schemas/BranchAndFinancialInstitutionIdentification6_EPC259-22_V4.0_DS02'
+        Cdtr:
+          $ref: '#/components/schemas/Party40Choice_EPC259-22_V4.0_DS15RTP'
+        CdtrAcct:
+          $ref: '#/components/schemas/CashAccount38'
+      required:
+      - Amt
+      - ReqdExctnDt
+      - PmtTpInf
+      - DbtrAgt
+      - CdtrAgt
+      - Cdtr
+      - CdtrAcct
+    OriginalTransactionReference29_EPC259-22_V4.0_DS04b:
+      type: object
+      properties:
+        Amt:
+          $ref: '#/components/schemas/AmountType4Choice_EPC259-22_V4.0_DS02'
+        ReqdExctnDt:
+          $ref: '#/components/schemas/DateAndDateTime2Choice_EPC259-22_V4.0_DS02'
+        XpryDt:
+          $ref: '#/components/schemas/DateAndDateTime2Choice_EPC259-22_V4.0_DS02'
+        PmtTpInf:
+          $ref: '#/components/schemas/PaymentTypeInformation26_EPC259-22_V4.0_DS04b'
+        RmtInf:
+          $ref: '#/components/schemas/RemittanceInformation16_EPC259-22_V4.0_DS04b'
+        DbtrAgt:
+          $ref: '#/components/schemas/BranchAndFinancialInstitutionIdentification6_EPC259-22_V4.0_DS02'
+        CdtrAgt:
+          $ref: '#/components/schemas/BranchAndFinancialInstitutionIdentification6_EPC259-22_V4.0_DS02'
+        Cdtr:
+          $ref: '#/components/schemas/PartyIdentification135_EPC259-22_V4.0_DS04b_3'
+        CdtrAcct:
+          $ref: '#/components/schemas/CashAccount38'
+      required:
+      - Amt
+      - ReqdExctnDt
+      - XpryDt
+      - PmtTpInf
+      - DbtrAgt
+      - CdtrAgt
+      - Cdtr
+      - CdtrAcct
+    OriginalTransactionReference29_EPC259-22_V4.0_DS08N:
+      type: object
+      properties:
+        Amt:
+          $ref: '#/components/schemas/AmountType4Choice_EPC259-22_V4.0_DS02'
+        ReqdExctnDt:
+          $ref: '#/components/schemas/DateAndDateTime2Choice_EPC259-22_V4.0_DS02'
+        XpryDt:
+          $ref: '#/components/schemas/DateAndDateTime2Choice_EPC259-22_V4.0_DS02'
+        PmtTpInf:
+          $ref: '#/components/schemas/PaymentTypeInformation26_EPC259-22_V4.0_DS04b'
+        RmtInf:
+          $ref: '#/components/schemas/RemittanceInformation16_EPC259-22_V4.0_DS04b'
+        Dbtr:
+          $ref: '#/components/schemas/PartyIdentification135_EPC259-22_V4.0_DS08N_2'
+        DbtrAcct:
+          $ref: '#/components/schemas/CashAccount38_EPC259-22_V4.0_DS08N'
+        DbtrAgt:
+          $ref: '#/components/schemas/BranchAndFinancialInstitutionIdentification6_EPC259-22_V4.0_DS02'
+        CdtrAgt:
+          $ref: '#/components/schemas/BranchAndFinancialInstitutionIdentification6_EPC259-22_V4.0_DS02'
+        Cdtr:
+          $ref: '#/components/schemas/PartyIdentification135_EPC259-22_V4.0_DS04b_3'
+        CdtrAcct:
+          $ref: '#/components/schemas/CashAccount38'
+      required:
+      - Amt
+      - ReqdExctnDt
+      - XpryDt
+      - PmtTpInf
+      - DbtrAgt
+      - CdtrAgt
+      - Cdtr
+      - CdtrAcct
+    OriginalTransactionReference29_EPC259-22_V4.0_DS08P:
+      type: object
+      properties:
+        Amt:
+          $ref: '#/components/schemas/AmountType4Choice_EPC259-22_V4.0_DS02'
+        ReqdExctnDt:
+          $ref: '#/components/schemas/DateAndDateTime2Choice_EPC259-22_V4.0_DS02'
+        XpryDt:
+          $ref: '#/components/schemas/DateAndDateTime2Choice_EPC259-22_V4.0_DS02'
+        PmtTpInf:
+          $ref: '#/components/schemas/PaymentTypeInformation26_EPC259-22_V4.0_DS04b'
+        RmtInf:
+          $ref: '#/components/schemas/RemittanceInformation16_EPC259-22_V4.0_DS04b'
+        Dbtr:
+          $ref: '#/components/schemas/PartyIdentification135_EPC259-22_V4.0_DS08N_2'
+        DbtrAcct:
+          $ref: '#/components/schemas/CashAccount38_EPC259-22_V4.0_DS08N'
+        DbtrAgt:
+          $ref: '#/components/schemas/BranchAndFinancialInstitutionIdentification6_EPC259-22_V4.0_DS02'
+        CdtrAgt:
+          $ref: '#/components/schemas/BranchAndFinancialInstitutionIdentification6_EPC259-22_V4.0_DS02'
+        Cdtr:
+          $ref: '#/components/schemas/PartyIdentification135_EPC259-22_V4.0_DS08P'
+        CdtrAcct:
+          $ref: '#/components/schemas/CashAccount38'
+      required:
+      - Amt
+      - ReqdExctnDt
+      - XpryDt
+      - PmtTpInf
+      - DbtrAgt
+      - CdtrAgt
+      - Cdtr
+      - CdtrAcct
+    OriginalTransactionReference29_EPC259-22_V4.0_DS16RTP:
+      type: object
+      properties:
+        Amt:
+          $ref: '#/components/schemas/AmountType4Choice_EPC259-22_V4.0_DS02'
+        ReqdExctnDt:
+          $ref: '#/components/schemas/DateAndDateTime2Choice_EPC259-22_V4.0_DS02'
+        XpryDt:
+          $ref: '#/components/schemas/DateAndDateTime2Choice_EPC259-22_V4.0_DS02'
+        PmtTpInf:
+          $ref: '#/components/schemas/PaymentTypeInformation26_EPC259-22_V4.0_DS04b'
+        RmtInf:
+          $ref: '#/components/schemas/RemittanceInformation16_EPC259-22_V4.0_DS04b'
+        DbtrAgt:
+          $ref: '#/components/schemas/BranchAndFinancialInstitutionIdentification6_EPC259-22_V4.0_DS02'
+        CdtrAgt:
+          $ref: '#/components/schemas/BranchAndFinancialInstitutionIdentification6_EPC259-22_V4.0_DS02'
+        Cdtr:
+          $ref: '#/components/schemas/PartyIdentification135_EPC259-22_V4.0_DS16RTP'
+        CdtrAcct:
+          $ref: '#/components/schemas/CashAccount38'
+      required:
+      - Amt
+      - ReqdExctnDt
+      - XpryDt
+      - PmtTpInf
+      - DbtrAgt
+      - CdtrAgt
+      - Cdtr
+      - CdtrAcct
+    Party38Choice:
+      oneOf:
+      - $ref: '#/components/schemas/OrganisationIdentification29_Wrapper'
+      - $ref: '#/components/schemas/PersonIdentification13_Wrapper'
+    Party38Choice_EPC259-22_V4.0_DS02:
+      oneOf:
+      - $ref: '#/components/schemas/OrganisationIdentification29_EPC259-22_V4.0_DS02_Wrapper'
+      - $ref: '#/components/schemas/PersonIdentification13_EPC259-22_V4.0_DS02_Wrapper'
+    Party38Choice_EPC259-22_V4.0_DS04b:
+      oneOf:
+      - $ref: '#/components/schemas/OrganisationIdentification29_EPC259-22_V4.0_DS04b_Wrapper'
+    Party38Choice_II:
+      oneOf:
+      - $ref: '#/components/schemas/OrganisationIdentification29_II_Wrapper'
+      - $ref: '#/components/schemas/PersonIdentification13_II_Wrapper'
+    Party40Choice_EPC259-22_V4.0_DS15RTP:
+      oneOf:
+      - $ref: '#/components/schemas/PartyIdentification135_EPC259-22_V4.0_DS15RTP_Wrapper'
+    PartyIdentification135:
+      type: object
+      properties:
+        Nm:
+          $ref: '#/components/schemas/Max140Text'
+        Id:
+          $ref: '#/components/schemas/Party38Choice_IV'
+      required:
+      - Id
+    PartyIdentification135_EPC259-22_V4.0_DS02_3:
+      type: object
+      properties:
+        Nm:
+          $ref: '#/components/schemas/Max140Text_EPC259-22_V4.0_DS02'
+        PstlAdr:
+          $ref: '#/components/schemas/PostalAddress24_EPC259-22_V4.0_DS02'
+        Id:
+          $ref: '#/components/schemas/Party38Choice_EPC259-22_V4.0_DS02_2'
+      required:
+      - Nm
+      - Id
+    PartyIdentification135_EPC259-22_V4.0_DS02_4:
+      type: object
+      properties:
+        Nm:
+          $ref: '#/components/schemas/Max140Text_EPC259-22_V4.0_DS02'
+        PstlAdr:
+          $ref: '#/components/schemas/PostalAddress24_EPC259-22_V4.0_DS02'
+        Id:
+          $ref: '#/components/schemas/Party38Choice_EPC259-22_V4.0_DS02_3'
+    PaymentCondition1_EPC259-22_V4.0_DS02:
+      type: object
+      properties:
+        AmtModAllwd:
+          $ref: '#/components/schemas/TrueFalseIndicator'
+        EarlyPmtAllwd:
+          $ref: '#/components/schemas/TrueFalseIndicator'
+        GrntedPmtReqd:
+          $ref: '#/components/schemas/TrueFalseIndicator'
+      required:
+      - AmtModAllwd
+      - EarlyPmtAllwd
+      - GrntedPmtReqd
+    PaymentConditionStatus1_EPC259-22_V4.0_DS08P:
+      type: object
+      properties:
+        AccptdAmt:
+          $ref: '#/components/schemas/ActiveCurrencyAndAmount_EPC259-22_V4.0_DS08P'
+        GrntedPmt:
+          $ref: '#/components/schemas/TrueFalseIndicator'
+        EarlyPmt:
+          $ref: '#/components/schemas/TrueFalseIndicator'
+      required:
+      - GrntedPmt
+      - EarlyPmt
+    PaymentIdentification6_EPC259-22_V4.0_DS02:
+      type: object
+      properties:
+        InstrId:
+          $ref: '#/components/schemas/Max35Text'
+        EndToEndId:
+          $ref: '#/components/schemas/Max35Text'
+      required:
+      - InstrId
+      - EndToEndId
+    PaymentTransaction102_EPC259-22_V4.0_DS12N:
+      type: object
+      properties:
+        CxlStsId:
+          $ref: '#/components/schemas/Max35Text'
+        OrgnlGrpInf:
+          $ref: '#/components/schemas/OriginalGroupInformation29_EPC259-22_V4.0_DS15RTP'
+        OrgnlInstrId:
+          $ref: '#/components/schemas/Max35Text'
+        OrgnlEndToEndId:
+          $ref: '#/components/schemas/Max35Text'
+        OrgnlTxId:
+          $ref: '#/components/schemas/Max35Text'
+        TxCxlSts:
+          $ref: '#/components/schemas/CancellationIndividualStatus1Code'
+        CxlStsRsnInf:
+          $ref: '#/components/schemas/CancellationStatusReason4_EPC259-22_V4.0_DS12N'
+        RsltnRltdInf:
+          $ref: '#/components/schemas/ResolutionData1_EPC259-22_V4.0_DS16RFC'
+        OrgnlTxRef:
+          $ref: '#/components/schemas/OriginalTransactionReference28_EPC259-22_V4.0_DS16RFC'
+      required:
+      - CxlStsId
+      - OrgnlGrpInf
+      - OrgnlInstrId
+      - OrgnlEndToEndId
+      - TxCxlSts
+      - CxlStsRsnInf
+      - OrgnlTxRef
+    PaymentTransaction102_EPC259-22_V4.0_DS12P:
+      type: object
+      properties:
+        CxlStsId:
+          $ref: '#/components/schemas/Max35Text'
+        OrgnlGrpInf:
+          $ref: '#/components/schemas/OriginalGroupInformation29_EPC259-22_V4.0_DS15RTP'
+        OrgnlInstrId:
+          $ref: '#/components/schemas/Max35Text'
+        OrgnlEndToEndId:
+          $ref: '#/components/schemas/Max35Text'
+        OrgnlTxId:
+          $ref: '#/components/schemas/Max35Text'
+        TxCxlSts:
+          $ref: '#/components/schemas/CancellationIndividualStatus1Code_II'
+        CxlStsRsnInf:
+          $ref: '#/components/schemas/CancellationStatusReason4_EPC259-22_V4.0_DS12P'
+        RsltnRltdInf:
+          $ref: '#/components/schemas/ResolutionData1_EPC259-22_V4.0_DS16RFC'
+        OrgnlTxRef:
+          $ref: '#/components/schemas/OriginalTransactionReference28_EPC259-22_V4.0_DS16RFC'
+      required:
+      - CxlStsId
+      - OrgnlGrpInf
+      - OrgnlInstrId
+      - OrgnlEndToEndId
+      - TxCxlSts
+      - CxlStsRsnInf
+      - OrgnlTxRef
+    PaymentTransaction103_EPC259-22_V4.0_DS16RFC:
+      type: object
+      properties:
+        OrgnlInstrId:
+          $ref: '#/components/schemas/Max35Text'
+        OrgnlEndToEndId:
+          $ref: '#/components/schemas/Max35Text'
+      required:
+      - OrgnlInstrId
+      - OrgnlEndToEndId
+    PaymentTransaction104:
+      type: object
+      properties:
+        StsId:
+          $ref: '#/components/schemas/Max35Text'
+        OrgnlInstrId:
+          $ref: '#/components/schemas/Max35Text'
+        OrgnlEndToEndId:
+          $ref: '#/components/schemas/Max35Text'
+        TxSts:
+          $ref: '#/components/schemas/ExternalPaymentTransactionStatus1Code'
+        StsRsnInf:
+          $ref: '#/components/schemas/StatusReasonInformation12'
+        ChrgsInf:
+          $ref: '#/components/schemas/Charges7'
+        OrgnlTxRef:
+          $ref: '#/components/schemas/OriginalTransactionReference29'
+      required:
+      - StsId
+      - OrgnlInstrId
+      - OrgnlEndToEndId
+      - TxSts
+      - StsRsnInf
+      - OrgnlTxRef
+    PaymentTransaction104_EPC259-22_V4.0_REDIRECT:
+      type: object
+      properties:
+        StsId:
+          $ref: '#/components/schemas/Max35Text'
+        OrgnlInstrId:
+          $ref: '#/components/schemas/Max35Text'
+        OrgnlEndToEndId:
+          $ref: '#/components/schemas/Max35Text'
+        TxSts:
+          $ref: '#/components/schemas/ExternalPaymentTransactionStatus1Code_EPC259-22_V4.0_REDIRECT'
+        StsRsnInf:
+          $ref: '#/components/schemas/StatusReasonInformation12_EPC259-22_V4.0_REDIRECT'
+        OrgnlTxRef:
+          $ref: '#/components/schemas/OriginalTransactionReference29_EPC259-22_V4.0_DS04b'
+      required:
+      - StsId
+      - OrgnlInstrId
+      - OrgnlEndToEndId
+      - TxSts
+      - StsRsnInf
+      - OrgnlTxRef
+    PaymentTransaction109_EPC259-22_V4.0_DS11:
+      type: object
+      properties:
+        CxlId:
+          $ref: '#/components/schemas/Max35Text'
+        OrgnlInstrId:
+          $ref: '#/components/schemas/Max35Text'
+        OrgnlEndToEndId:
+          $ref: '#/components/schemas/Max35Text'
+        CxlRsnInf:
+          $ref: '#/components/schemas/PaymentCancellationReason5_EPC259-22_V4.0_DS11'
+        OrgnlTxRef:
+          $ref: '#/components/schemas/OriginalTransactionReference28_EPC259-22_V4.0_DS11'
+      required:
+      - CxlId
+      - OrgnlInstrId
+      - OrgnlEndToEndId
+      - CxlRsnInf
+      - OrgnlTxRef
+    PaymentTransaction109_EPC259-22_V4.0_DS15RFC:
+      type: object
+      properties:
+        CxlId:
+          $ref: '#/components/schemas/Max35Text'
+        OrgnlInstrId:
+          $ref: '#/components/schemas/Max35Text'
+        OrgnlEndToEndId:
+          $ref: '#/components/schemas/Max35Text'
+        CxlRsnInf:
+          $ref: '#/components/schemas/PaymentCancellationReason5_EPC259-22_V4.0_DS15RFC'
+        OrgnlTxRef:
+          $ref: '#/components/schemas/OriginalTransactionReference28_EPC259-22_V4.0_DS16RFC'
+      required:
+      - CxlId
+      - OrgnlInstrId
+      - OrgnlEndToEndId
+      - CxlRsnInf
+      - OrgnlTxRef
+    PaymentTypeInformation26_EPC259-22_V4.0_DS02:
+      type: object
+      properties:
+        SvcLvl:
+          $ref: '#/components/schemas/ServiceLevel8Choice'
+        LclInstrm:
+          $ref: '#/components/schemas/LocalInstrument2Choice'
+        CtgyPurp:
+          $ref: '#/components/schemas/CategoryPurpose1Choice_EPC259-22_V4.0_DS02'
+      required:
+      - SvcLvl
+      - LclInstrm
+    PaymentTypeInformation27_EPC259-22_V4.0_DS15RTP:
+      type: object
+      properties:
+        SvcLvl:
+          $ref: '#/components/schemas/ServiceLevel8Choice'
+        LclInstrm:
+          $ref: '#/components/schemas/LocalInstrument2Choice'
+      required:
+      - SvcLvl
+      - LclInstrm
+    PostalAddress24_EPC259-22_V4.0_DS02:
+      type: object
+      description: >
+            Postal address of the debtor (EPC SRTP Guidelines v4.0).
+            SEPA Usage Rules:
+            - Town Name (TwnNm) and Country (Ctry) are mandatory in both Structured and Hybrid formats.
+            - Structured Address (Recommended): AdrLine must NOT be used. TwnNm and Ctry must be present.
+            - Hybrid Address (Alternative): TwnNm and Ctry must be present; AdrLine must contain at least one occurrence, up to two allowed
+            Additional recommendations:
+            - It is recommended to provide as many structured elements as possible.
+            - These rules apply equally to Debtor and Creditor addresses.
+            - These rules must be enforced at business layer; JSON Schema cannot enforce conditional branching (Structured vs Hybrid) alone.            
+      properties:
+        TwnNm:
+          type: string
+          description: >
+            Town name of the debtor’s postal address.
+            SEPA Usage Rule: Mandatory (Multiplicity: [1..1])
+        Ctry:
+          allOf:
+            - $ref: '#/components/schemas/CountryCode'
+            - description: >
+                Country code of the address (ISO 3166-1 alpha-2).
+                SEPA Usage Rule: Mandatory (Multiplicity: [1..1])
+        AdrLine:
+          type: array
+          items:
+            $ref: '#/components/schemas/Max70Text'
+          maxItems: 2
+          description: >
+            Address line(s).
+            Usage Rule (Hybrid Address only):
+                - At least one occurrence mandatory.
+                - Up to 2 occurrences allowed.
+                - Not allowed in Structured Address.
+      required:
+        - TwnNm
+        - Ctry
+    ProxyAccountIdentification1_EPC259-22_V4.0_DS02:
+      type: object
+      properties:
+        Tp:
+          $ref: '#/components/schemas/ProxyAccountType1Choice_EPC259-22_V4.0_DS02'
+        Id:
+          $ref: '#/components/schemas/Max320Text'
+      required:
+      - Id
+    Purpose2Choice_EPC259-22_V4.0_DS02:
+      oneOf:
+      - $ref: '#/components/schemas/ExternalPurpose1Code_Wrapper'
+    RemittanceInformation16_EPC259-22_V4.0_DS15RTP:
+      type: object
+      description: >
+        SEPA Rulebook:
+        - AT-T009 RTP Remittance Information to be inserted in the payment (containing possibly AT-S002 Payee’s end-to-end reference of the RTP and AT-T019 Credit note amount*), mandatory if provided in DS-02.
+        - AT-S005 Expiry Date/Time of the RTP.
+        - AT-S013 Placeholder for Charges.
+        SEPA Usage Rule: 
+        - Mandatory.
+        - Both ‘Unstructured’ and ‘Structured’ can be present:
+        - AT-T009 can be present either in ‘Unstructured’ or ‘Structured’ and may also contain AT-S002, and in 'Structured', also AT-T019.
+        - AT-S005, AT-T019 and AT-S013 can be present only in 'Structured'.
+        - Only the occurrence (Unstructured or Structured) containing AT-T009 is to be provided in the payment.
+      properties:
+        Ustrd:
+          type: array
+          items:
+            $ref: '#/components/schemas/Max140Text'
+          maxItems: 3
+          description: |
+            SEPA Usage Rules:
+            - Only one occurrence is allowed.
+            - Must include AT-T009 if this path is chosen.
+            - May also include:
+              - AT-S002 (Payee’s end-to-end reference),
+              - AT-E002 (commercial trade name if different from AT-E001),
+              - location and date/time of transaction.
+            - Elements must be delimited by slashes (or another consistent delimiter if slash is reserved).
+            - Example: The Shopping Paradise/Boulevard des Marchands 123/2020-12-24T11:37/Purchase Nr1234567890AZ - Merry Christmas.
+            - For further information, please refer to “EPC088-22 EPC Guidance Document – Improve Transparency for Retail Payment End-Users”
+        Strd:
+          $ref: '#/components/schemas/StructuredRemittanceInformation16_EPC259-22_V4.0_DS15RTP'
+    RemittanceInformation21_EPC259-22_V4.0_DS02:
+      type: object
+      properties:
+        Ustrd:
+          type: array
+          items:
+            $ref: '#/components/schemas/Max140Text'
+          maxItems: 2
+        Strd:
+          $ref: '#/components/schemas/StructuredRemittanceInformation17_EPC259-22_V4.0_DS02'
+    RemittanceLocation7_EPC259-22_V4.0_DS02:
+      type: object
+      properties:
+        RmtId:
+          $ref: '#/components/schemas/Max35Text'
+        RmtLctnDtls:
+          type: array
+          items:
+            $ref: '#/components/schemas/RemittanceLocationData1_EPC259-22_V4.0_DS02'
+          maxItems: 2
+    ResolutionData1_EPC259-22_V4.0_DS16RFC:
+      type: object
+      properties:
+        Chrgs:
+          $ref: '#/components/schemas/Charges7_EPC259-22_V4.0_DS04b'
+      required:
+      - Chrgs
+    StatusReasonInformation12_EPC259-22_V4.0_DS04b:
+      type: object
+      properties:
+        Orgtr:
+          $ref: '#/components/schemas/PartyIdentification135_EPC259-22_V4.0_DS04b'
+        Rsn:
+          $ref: '#/components/schemas/StatusReason6Choice_EPC259-22_V4.0_DS04b'
+      required:
+      - Orgtr
+      - Rsn
+    StatusReasonInformation12_EPC259-22_V4.0_DS08N:
+      type: object
+      properties:
+        Orgtr:
+          $ref: '#/components/schemas/PartyIdentification135_EPC259-22_V4.0_DS08N_2'
+        Rsn:
+          $ref: '#/components/schemas/StatusReason6Choice_EPC259-22_V4.0_DS08N'
+      required:
+      - Orgtr
+      - Rsn
+    StatusReasonInformation12_EPC259-22_V4.0_DS08P:
+      type: object
+      properties:
+        Orgtr:
+          $ref: '#/components/schemas/PartyIdentification135_EPC259-22_V4.0_DS08N_2'
+        AddtlInf:
+          type: array
+          items:
+            $ref: '#/components/schemas/Max105Text'
+          maxItems: 3
+          description: |
+            SEPA Rulebook:
+            - AT-R094 Payment instrument accepted (mandatory if provided in DS-07).
+            - AT-R095 Identifier of the payment guarantee provider* (mandatory if provided in DS-07).
+            - AT-R096 Response to the Request for payment guarantee* (mandatory if provided in DS-07).
+            - AT-R114 Payment initiation status related information* (mandatory if provided in DS-07).
+            SEPA Usage Rule:
+            - Up to three occurrences are allowed. One for AT-R094, one for AT-R096 (including if applicable AT-R095) and one for AT-R114.
+            - The occurrence dedicated to the payment instrument is mandatory if ‘Local Instrument’ code “CTP”or “ITP” is included in the original pain.013 message. It specifies which payment instrument is accepted by the Payer and must begin with “ATR094/” followed by one of the codes below:
+                - If related to SEPA payments (i.e. if ‘Service Level’ is “SEPA”), either "SCT" or "SCT Inst" is allowed.
+                - If related to other payments within SEPA (i.e. if ‘Service Level’ is “SRTP”),“TRF” or “INST” is allowed and the use of other ISO codes may be agreed bilaterally or multilaterally.
+            - The occurrence dedicated to the payment guarantee must begin with “ATR096/”and followed either by:
+                - The identifier of the payment guarantee provider (AT-R095) in case the payment guarantee request is accepted by the Payer; or
+                - “NOPG” (No Payment Guarantee) in case the payment guarantee request is refused by the Payer.
+            - The occurrence dedicated to payment initiation status must begin with “ATR114/” followed by the payment initiation status (or payment execution status in case of an instant payment) related information (e.g., the PSP identification, the payment reference).
+      required:
+      - Orgtr
+    StatusReasonInformation12_EPC259-22_V4.0_DS16RTP:
+      type: object
+      properties:
+        Orgtr:
+          $ref: '#/components/schemas/PartyIdentification135_EPC259-22_V4.0_DS04b'
+        Rsn:
+          $ref: '#/components/schemas/StatusReason6Choice_EPC259-22_V4.0_DS16RTP'
+      required:
+      - Orgtr
+      - Rsn
+    AccountIdentification4Choice:
+      oneOf:
+      - $ref: '#/components/schemas/IBAN2007Identifier_Wrapper'
+    ActiveCurrencyAndAmount_EPC259-22_V4.0_DS08P:
+      minimum: 0.01
+      type: number
+    ActiveOrHistoricCurrencyAndAmount_EPC259-22_V4.0_DS02:
+      minimum: 0.01
+      maximum: 999999999.99
+      type: number
+      description: |
+        SEPA Usage Rule: V4.0 In case of SCT and SCT Inst: Amount must be 0.01 or more and 999999999.99 or less.
+    ActiveOrHistoricCurrencyAndAmount_EPC259-22_V4.0_DS04b:
+      minimum: 0.01
+      type: number
+    AdviceType1Code:
+      enum:
+      - ADND
+      - ADWD
+      type: string
+    BICFIDec2014Identifier:
+      pattern: '[A-Z0-9]{4,4}[A-Z]{2,2}[A-Z0-9]{2,2}([A-Z0-9]{3,3}){0,1}'
+      type: string
+    CancellationIndividualStatus1Code:
+      enum:
+      - RJCR
+      type: string
+    CancellationIndividualStatus1Code_II:
+      enum:
+      - ACCR
+      type: string
+    CancellationStatusReason3Choice_EPC259-22_V4.0_DS16RFC:
+      oneOf:
+      - $ref: '#/components/schemas/ExternalPaymentCancellationRejection1Code_Wrapper'
+    CancellationStatusReason4_EPC259-22_V4.0_DS12N:
+      type: object
+      properties:
+        Orgtr:
+          $ref: '#/components/schemas/PartyIdentification135_EPC259-22_V4.0_DS04b'
+        Rsn:
+          $ref: '#/components/schemas/CancellationStatusReason3Choice_EPC259-22_V4.0_DS12N'
+        AddtlInf:
+          type: array
+          items:
+            $ref: '#/components/schemas/Max105Text'
+          maxItems: 4
+      required:
+      - Orgtr
+      - Rsn
+    CancellationStatusReason4_EPC259-22_V4.0_DS12P:
+      type: object
+      properties:
+        Orgtr:
+          $ref: '#/components/schemas/PartyIdentification135_EPC259-22_V4.0_DS04b'
+        AddtlInf:
+          type: array
+          items:
+            $ref: '#/components/schemas/Max105Text'
+          maxItems: 4
+      required:
+      - Orgtr
+    CashAccount38_EPC259-22_V4.0_DS08N:
+      type: object
+      properties:
+        Id:
+          $ref: '#/components/schemas/AccountIdentification4Choice_EPC259-22_V4.0_DS08N'
+        Nm:
+          $ref: '#/components/schemas/Max70Text'
+        Prxy:
+          $ref: '#/components/schemas/ProxyAccountIdentification1_EPC259-22_V4.0_DS08N'
+      required:
+      - Id
+    CategoryPurpose1Choice_EPC259-22_V4.0_DS02:
+      oneOf:
+      - $ref: '#/components/schemas/ExternalCategoryPurpose1Code_Wrapper'
+      - $ref: '#/components/schemas/Max35Text_Wrapper'
+    Charges7:
+      type: object
+      properties:
+        Amt:
+          $ref: '#/components/schemas/ActiveOrHistoricCurrencyAndAmount_EPC259-22_V4.0_DS02'
+        Agt:
+          $ref: '#/components/schemas/BranchAndFinancialInstitutionIdentification6_EPC259-22_V4.0_DS02'
+      required:
+      - Amt
+      - Agt
+    CountryCode:
+      pattern: '[A-Z]{2,2}'
+      type: string
+    DocumentFormat1Choice_EPC259-22_V4.0_DS02:
+      oneOf:
+      - $ref: '#/components/schemas/ExternalDocumentFormat1Code_Wrapper'
+    DocumentType1Choice_EPC259-22_V4.0_DS02:
+      oneOf:
+      - $ref: '#/components/schemas/ExternalDocumentType1Code_Wrapper'
+    ExternalPaymentTransactionStatus1Code_EPC259-22_V4.0_REDIRECT:
+      maxLength: 4
+      minLength: 1
+      enum:
+      - ""
+      - ACTC
+      type: string
+    ExternalPurpose1Code:
+      maxLength: 4
+      minLength: 1
+      type: string
+    GenericAccountIdentification1_EPC259-22_V4.0_DS02:
+      type: object
+      properties:
+        Id:
+          $ref: '#/components/schemas/Max34Text'
+        SchmeNm:
+          $ref: '#/components/schemas/AccountSchemeName1Choice_EPC259-22_V4.0_DS02'
+        Issr:
+          $ref: '#/components/schemas/Max35Text'
+      required:
+      - Id
+    GenericFinancialIdentification1:
+      type: object
+      properties:
+        Id:
+          $ref: '#/components/schemas/Max35Text'
+        SchmeNm:
+          $ref: '#/components/schemas/FinancialIdentificationSchemeName1Choice'
+        Issr:
+          $ref: '#/components/schemas/Max35Text'
+      required:
+      - Id
+    IBAN2007Identifier:
+      pattern: '[A-Z]{2,2}[0-9]{2,2}[a-zA-Z0-9]{1,30}'
+      type: string
+    LEIIdentifier:
+      pattern: '[A-Z0-9]{18,18}[0-9]{2,2}'
+      type: string
+    LocalInstrument2Choice:
+      oneOf:
+      - $ref: '#/components/schemas/ExternalLocalInstrument1Code_Wrapper'
+      - $ref: '#/components/schemas/Max35Text_Wrapper'
+    Max105Text:
+      maxLength: 105
+      minLength: 1
+      type: string
+    Max10MbBinary:
+      maxLength: 10485760
+      minLength: 1
+      type: string
+    Max140Text:
+      maxLength: 140
+      minLength: 1
+      type: string
+    Max2048Text:
+      maxLength: 2048
+      minLength: 1
+      type: string
+    OrganisationIdentification29:
+      type: object
+      properties:
+        AnyBIC:
+          $ref: '#/components/schemas/AnyBICDec2014Identifier'
+        LEI:
+          $ref: '#/components/schemas/LEIIdentifier'
+        Othr:
+          type: array
+          items:
+            $ref: '#/components/schemas/GenericOrganisationIdentification1'
+    OrganisationIdentification29_EPC259-22_V4.0_DS02:
+      type: object
+      properties:
+        AnyBIC:
+          $ref: '#/components/schemas/AnyBICDec2014Identifier'
+        LEI:
+          $ref: '#/components/schemas/LEIIdentifier'
+        Othr:
+          type: array
+          items:
+            $ref: '#/components/schemas/GenericOrganisationIdentification1_EPC259-22_V4.0_DS02'
+          maxItems: 2
+    OrganisationIdentification29_EPC259-22_V4.0_DS04b:
+      type: object
+      properties:
+        AnyBIC:
+          $ref: '#/components/schemas/AnyBICDec2014Identifier'
+        LEI:
+          $ref: '#/components/schemas/LEIIdentifier'
+        Othr:
+          $ref: '#/components/schemas/GenericOrganisationIdentification1_EPC259-22_V4.0_DS04b'
+    OrganisationIdentification29_II:
+      type: object
+      properties:
+        AnyBIC:
+          $ref: '#/components/schemas/AnyBICDec2014Identifier'
+        LEI:
+          $ref: '#/components/schemas/LEIIdentifier'
+        Othr:
+          type: array
+          items:
+            $ref: '#/components/schemas/GenericOrganisationIdentification1_EPC259-22_V4.0_DS04b'
+    OriginalTransactionReference28_EPC259-22_V4.0_DS11:
+      type: object
+      properties:
+        Amt:
+          $ref: '#/components/schemas/AmountType4Choice_EPC259-22_V4.0_DS02'
+        ReqdExctnDt:
+          $ref: '#/components/schemas/DateAndDateTime2Choice_EPC259-22_V4.0_DS02'
+        PmtTpInf:
+          $ref: '#/components/schemas/PaymentTypeInformation27_EPC259-22_V4.0_DS15RTP'
+        RmtInf:
+          $ref: '#/components/schemas/RemittanceInformation16_EPC259-22_V4.0_DS04b'
+        DbtrAgt:
+          $ref: '#/components/schemas/BranchAndFinancialInstitutionIdentification6_EPC259-22_V4.0_DS02'
+        CdtrAgt:
+          $ref: '#/components/schemas/BranchAndFinancialInstitutionIdentification6_EPC259-22_V4.0_DS02'
+        Cdtr:
+          $ref: '#/components/schemas/Party40Choice_EPC259-22_V4.0_DS11_3'
+        CdtrAcct:
+          $ref: '#/components/schemas/CashAccount38'
+      required:
+      - Amt
+      - ReqdExctnDt
+      - PmtTpInf
+      - DbtrAgt
+      - CdtrAgt
+      - Cdtr
+      - CdtrAcct
+    OriginalTransactionReference29:
+      type: object
+      properties:
+        Amt:
+          $ref: '#/components/schemas/AmountType4Choice_EPC259-22_V4.0_DS02'
+        ReqdExctnDt:
+          $ref: '#/components/schemas/DateAndDateTime2Choice_EPC259-22_V4.0_DS02'
+        XpryDt:
+          $ref: '#/components/schemas/DateAndDateTime2Choice_EPC259-22_V4.0_DS02'
+        PmtTpInf:
+          $ref: '#/components/schemas/PaymentTypeInformation26_EPC259-22_V4.0_DS04b'
+        RmtInf:
+          $ref: '#/components/schemas/RemittanceInformation16'
+        DbtrAgt:
+          $ref: '#/components/schemas/BranchAndFinancialInstitutionIdentification6_EPC259-22_V4.0_DS02'
+        CdtrAgt:
+          $ref: '#/components/schemas/BranchAndFinancialInstitutionIdentification6_EPC259-22_V4.0_DS02'
+        Cdtr:
+          $ref: '#/components/schemas/PartyIdentification135'
+        CdtrAcct:
+          $ref: '#/components/schemas/CashAccount38'
+      required:
+      - Amt
+      - ReqdExctnDt
+      - XpryDt
+      - PmtTpInf
+      - DbtrAgt
+      - CdtrAgt
+      - Cdtr
+      - CdtrAcct
+    Party38Choice_EPC259-22_V4.0_DS02_2:
+      oneOf:
+      - $ref: '#/components/schemas/OrganisationIdentification29_EPC259-22_V4.0_DS02_2_Wrapper'
+      - $ref: '#/components/schemas/PersonIdentification13_EPC259-22_V4.0_DS02_2_Wrapper'
+    Party38Choice_EPC259-22_V4.0_DS02_3:
+      oneOf:
+      - $ref: '#/components/schemas/OrganisationIdentification29_EPC259-22_V4.0_DS02_Wrapper'
+      - $ref: '#/components/schemas/PersonIdentification13_EPC259-22_V4.0_DS02_2_Wrapper'
+    Party38Choice_IV:
+      oneOf:
+      - $ref: '#/components/schemas/OrganisationIdentification29_EPC259-22_V4.0_DS04b_Wrapper'
+      - $ref: '#/components/schemas/PersonIdentification13_IV_Wrapper'
+    PartyAndSignature3:
+      type: object
+      properties:
+        Pty:
+          $ref: '#/components/schemas/PartyIdentification135_II'
+        Sgntr:
+          $ref: '#/components/schemas/SkipPayload'
+      required:
+      - Pty
+      - Sgntr
+    PartyIdentification135_EPC259-22_V4.0_DS04b_3:
+      type: object
+      properties:
+        Nm:
+          $ref: '#/components/schemas/Max140Text_EPC259-22_V4.0_DS02'
+        Id:
+          $ref: '#/components/schemas/Party38Choice_EPC259-22_V4.0_DS04b_2'
+      required:
+      - Nm
+      - Id
+    PartyIdentification135_EPC259-22_V4.0_DS08P:
+      type: object
+      properties:
+        Nm:
+          $ref: '#/components/schemas/Max140Text_CreditorName_DSXX'
+        Id:
+          $ref: '#/components/schemas/Party38Choice_EPC259-22_V4.0_DS04b_2'
+      required:
+      - Nm
+      - Id
+    PartyIdentification135_EPC259-22_V4.0_DS08N_2:
+      type: object
+      properties:
+        Nm:
+          $ref: '#/components/schemas/Max140Text_CreditorName_DSXX'
+        Id:
+          $ref: '#/components/schemas/Party38Choice_EPC259-22_V4.0_DS04b_2'
+      required:
+      - Nm
+      - Id
+    PartyIdentification135_EPC259-22_V4.0_DS15RTP:
+      type: object
+      properties:
+        Nm:
+          $ref: '#/components/schemas/Max140Text_CreditorName_DSXX_2'
+        Id:
+          $ref: '#/components/schemas/Party38Choice_EPC259-22_V4.0_DS15RTP'
+      required:
+      - Nm
+      - Id
+    PartyIdentification135_EPC259-22_V4.0_DS16RTP:
+      type: object
+      properties:
+        Nm:
+          $ref: '#/components/schemas/Max140Text_CreditorName_DSXX_2'
+        Id:
+          $ref: '#/components/schemas/Party38Choice_EPC259-22_V4.0_DS15RTP'
+      required:
+      - Id    
+    PaymentCancellationReason5_EPC259-22_V4.0_DS11:
+      type: object
+      properties:
+        Orgtr:
+          allOf:  
+            - $ref: '#/components/schemas/PartyIdentification135_EPC259-22_V4.0_DS11_3'
+            - description: |
+                SEPA Rulebook Reference:
+                - AT-R002 Identification of the party initiating the response or “R” message.
+                SEPA Usage Rules:
+                - Mandatory.
+                - The Payee or the Payee's RTP Service Provider is the Originator of the RfC.
+                - If the Payee is the Originator of the RfC, only 'Name' and 'Identification' are allowed.
+                - If the Payee's RTP Service Provider is the Originator of the RfC, only 'Identification' is allowed.
+        Rsn:
+          allOf:
+            - $ref: '#/components/schemas/CancellationReason33Choice_EPC259-22_V4.0_DS11'
+            - description: |
+                SEPA Rulebook Reference:
+                - AT-R106 Reason code for the Request for Cancellation of the RTP.
+                SEPA Usage Rule:
+                - Mandatory.
+        AddtlInf:
+          type: array
+          items:
+            $ref: '#/components/schemas/Max105Text'
+          maxItems: 3
+          description: |
+           SEPA Rulebook References:
+           - AT-S005 Expiry Date/Time of the RTP.
+           - AT-R107 Additional information to AT-R106 Reason code for the Request for Cancellation (RfC) of the RTP.
+           - AT-S013 Placeholder for charges.
+           - AT-T002 Amount of the RTP.
+           SEPA Usage Rules:
+           - Mandatory.
+           - EITHER up to three occurrences are allowed:
+               - One mandatory occurrence starting with “ATS005/” followed by the Expiry Date/time of the RTP.
+               - One optional occurrence starting with “ATR107/” followed by the description of the attribute.
+               - One optional occurrence starting with “ATS013/” followed by charges related to the processing of the RfC.
+           - OR, in the first occurrence of ‘Transaction Information’ and only in case of instalment payments,
+             one mandatory occurrence of ‘Additional Information’ must be provided, mentioning “ATT002 Amount of the RTP”.
+
+      required:
+      - Orgtr
+      - Rsn
+      - AddtlInf
+    PaymentCancellationReason5_EPC259-22_V4.0_DS15RFC:
+      type: object
+      properties:
+        Orgtr:
+          $ref: '#/components/schemas/PartyIdentification135_EPC259-22_V4.0_DS15RFC_3'
+        Rsn:
+          $ref: '#/components/schemas/CancellationReason33Choice_EPC259-22_V4.0_DS11'
+        AddtlInf:
+          type: array
+          items:
+            $ref: '#/components/schemas/Max105Text'
+          maxItems: 5
+      required:
+      - Orgtr
+      - Rsn
+    PaymentTypeInformation26_EPC259-22_V4.0_DS04b:
+      type: object
+      properties:
+        SvcLvl:
+          $ref: '#/components/schemas/ServiceLevel8Choice'
+        LclInstrm:
+          $ref: '#/components/schemas/LocalInstrument2Choice'
+      required:
+      - SvcLvl
+      - LclInstrm
+    PersonIdentification13:
+      type: object
+      properties:
+        DtAndPlcOfBirth:
+          $ref: '#/components/schemas/DateAndPlaceOfBirth1'
+        Othr:
+          type: array
+          items:
+            $ref: '#/components/schemas/GenericPersonIdentification1'
+    PersonIdentification13_EPC259-22_V4.0_DS02:
+      type: object
+      properties:
+        Othr:
+          type: array
+          items:
+            $ref: '#/components/schemas/GenericPersonIdentification1_EPC259-22_V4.0_DS02'
+          maxItems: 2
+    PersonIdentification13_II:
+      type: object
+      properties:
+        DtAndPlcOfBirth:
+          $ref: '#/components/schemas/DateAndPlaceOfBirth1'
+        Othr:
+          type: array
+          items:
+            $ref: '#/components/schemas/GenericPersonIdentification1_II'
+    ProxyAccountType1Choice_EPC259-22_V4.0_DS02:
+      oneOf:
+      - $ref: '#/components/schemas/ExternalProxyAccountType1Code_Wrapper'
+      - $ref: '#/components/schemas/Max35Text_Wrapper'
+    RemittanceInformation16_EPC259-22_V4.0_DS04b:
+      type: object
+      properties:
+        Ustrd:
+          $ref: '#/components/schemas/Max140Text'
+        Strd:
+          $ref: '#/components/schemas/StructuredRemittanceInformation16_EPC259-22_V4.0_DS04b'
+    RemittanceLocationData1_EPC259-22_V4.0_DS02:
+      type: object
+      properties:
+        Mtd:
+          $ref: '#/components/schemas/RemittanceLocationMethod2Code'
+        ElctrncAdr:
+          allOf:
+            - $ref: '#/components/schemas/Max2048Text'
+            - description: |
+                SEPA Rulebook references:
+                - AT-S008: URL sent by the Payee to the Payer in the RTP
+                - AT-S010: Required URL flag
+                - AT-S015: Return to merchant URL
+                SEPA Usage Rules:
+                - Mandatory if provided in DS-01
+                - One optional occurrence containing AT-S008 or AT-S010 as follows:
+                  - "ATS008/" followed by a space and then the URL sent by the Payee to the Payer in the RTP.
+                  - "ATS010/" followed by a space and then the URL sent by the Payee to the Payer in the RTP.
+                - One optional occurrence containing AT-S015 as follows:
+                  - "ATS015/" followed by a space and the return to merchant URL.
+                  In case of multiple URLs a space shall be used as a separator.
+      required:
+      - Mtd
+    ServiceLevel8Choice:
+      oneOf:
+      - $ref: '#/components/schemas/ExternalServiceLevel1Code_Wrapper'
+    StatusReason6Choice_EPC259-22_V4.0_DS04b:
+      oneOf:
+      - $ref: '#/components/schemas/ExternalStatusReason1Code_Wrapper'
+      - $ref: '#/components/schemas/Max35Text_URLN_Reason_DS04b_Prtry'
+    StatusReason6Choice_EPC259-22_V4.0_DS08N:
+      oneOf:
+      - $ref: '#/components/schemas/ExternalStatusReason1Code_II_Wrapper'
+    StatusReason6Choice_EPC259-22_V4.0_DS16RTP:
+      oneOf:
+      - $ref: '#/components/schemas/ExternalStatusReason1Code_III_Wrapper'
+      - $ref: '#/components/schemas/Max35Text_Wrapper'
+    StatusReasonInformation12:
+      type: object
+      properties:
+        Orgtr:
+          $ref: '#/components/schemas/PartyIdentification135'
+        Rsn:
+          $ref: '#/components/schemas/StatusReason6Choice_EPC259-22_V4.0_DS04b'
+      required:
+      - Orgtr
+      - Rsn
+    StatusReasonInformation12_EPC259-22_V4.0_REDIRECT:
+      type: object
+      properties:
+        Orgtr:
+          $ref: '#/components/schemas/PartyIdentification135_EPC259-22_V4.0_DS04b'
+        AddtlInf:
+          $ref: '#/components/schemas/Max105Text'
+      required:
+      - Orgtr
+      - AddtlInf
+    StructuredRemittanceInformation16_EPC259-22_V4.0_DS15RTP:
+      type: object
+      description: |
+        SEPA Rulebook:
+        - AT-S005 Expiry Date/Time of the RTP
+        - AT-T009 RTP Remittance Information to be inserted in the payment (containing possibly AT-S002 Payee’s end-to-end reference of the RTP and AT-T019 Credit note amount*)
+        SEPA Usage Rule:
+        - Mandatory if Structured path is used.
+        - Only one occurrence is allowed.
+        - The Payee has to check with its counterparty if this element can be used, otherwise it cannot be guaranteed that this information will be included in the payment.
+        SEPA Format Rule:
+        - ‘Structured’ can be used, provided the tags and the data within the ‘Structured’ element (i.e. excluding &lt;Strd&gt; and &lt;/Strd&gt;) do not exceed 140 characters in length.
+      properties:
+        RfrdDocAmt:
+          $ref: '#/components/schemas/RemittanceAmount2_EPC259-22_V4.0_DS15RTP'
+        CdtrRefInf:
+          $ref: '#/components/schemas/CreditorReferenceInformation2_EPC259-22_V4.0_DS02'
+        AddtlRmtInf:
+          type: array
+          description: |
+            SEPA Rulebook:
+            - AT-S005 Expiry Date/Time of the RTP.
+            - AT-S013 Placeholder for Charges.
+            SEPA Usage Rule:
+            - Mandatory.
+            - Up to two occurrences are allowed:
+            - A first mandatory occurrence starting with “ATS005/” followed by the Expiry Date/time of the RTP. 
+            - A second optional occurrence starting with “ATS013/” followed by charges related to the processing of the RTP   
+          items:
+            $ref: '#/components/schemas/Max140Text'
+          maxItems: 2
+    StructuredRemittanceInformation17_EPC259-22_V4.0_DS02:
+      type: object
+      properties:
+        RfrdDocAmt:
+          $ref: '#/components/schemas/RemittanceAmount2_EPC259-22_V4.0_DS02'
+        CdtrRefInf:
+          $ref: '#/components/schemas/CreditorReferenceInformation2_EPC259-22_V4.0_DS02'
+    TrueFalseIndicator:
+      type: boolean
+    AccountIdentification4Choice_EPC259-22_V4.0_DS08N:
+      oneOf:
+      - $ref: '#/components/schemas/IBAN2007Identifier_Wrapper'
+      - $ref: '#/components/schemas/GenericAccountIdentification1_EPC259-22_V4.0_DS08N_Wrapper'
+    AccountSchemeName1Choice_EPC259-22_V4.0_DS02:
+      oneOf:
+      - $ref: '#/components/schemas/ExternalAccountIdentification1Code_Wrapper'
+      - $ref: '#/components/schemas/Max35Text_Wrapper'
+    AnyBICDec2014Identifier:
+      pattern: '[A-Z0-9]{4,4}[A-Z]{2,2}[A-Z0-9]{2,2}([A-Z0-9]{3,3}){0,1}'
+      type: string
+    CancellationReason33Choice_EPC259-22_V4.0_DS11:
+      oneOf:
+      - $ref: '#/components/schemas/ExternalCancellationReason1Code_Wrapper'
+    CancellationStatusReason3Choice_EPC259-22_V4.0_DS12N:
+      oneOf:
+      - $ref: '#/components/schemas/ExternalPaymentCancellationRejection1Code_II_Wrapper'
+    CreditorReferenceInformation2_EPC259-22_V4.0_DS02:
+      type: object
+      properties:
+        Tp:
+          $ref: '#/components/schemas/CreditorReferenceType2_EPC259-22_V4.0_DS02'
+        Ref:
+          $ref: '#/components/schemas/Max35Text'
+      required:
+      - Tp
+      - Ref
+    DateAndPlaceOfBirth1:
+      type: object
+      properties:
+        BirthDt:
+          $ref: '#/components/schemas/ISODate'
+        PrvcOfBirth:
+          $ref: '#/components/schemas/Max35Text'
+        CityOfBirth:
+          $ref: '#/components/schemas/Max35Text'
+        CtryOfBirth:
+          $ref: '#/components/schemas/CountryCode'
+      required:
+      - BirthDt
+      - CityOfBirth
+      - CtryOfBirth
+    ExternalCategoryPurpose1Code:
+      maxLength: 4
+      minLength: 1
+      type: string
+    ExternalDocumentFormat1Code:
+      maxLength: 4
+      minLength: 1
+      type: string
+    ExternalDocumentType1Code:
+      maxLength: 4
+      minLength: 1
+      type: string
+    ExternalLocalInstrument1Code:
+      maxLength: 35
+      minLength: 1
+      type: string
+      description: |
+        SEPA Usage Rule: V4.0 Code restrictions removed (previously limited to CTP, INST, ITP, TRF).
+    ExternalPaymentCancellationRejection1Code:
+      maxLength: 4
+      minLength: 1
+      enum:
+      - AEXR
+      - RCAR
+      - RCNR
+      - RCPR
+      type: string
+    ExternalPaymentCancellationRejection1Code_II:
+      maxLength: 4
+      minLength: 1
+      enum:
+      - AACR
+      - ACLR
+      - AEXR
+      - ARFR
+      - ARJR
+      - RR04
+      - URTP
+      type: string    
+    ExternalProxyAccountType1Code:
+      maxLength: 4
+      minLength: 1
+      type: string
+    ExternalServiceLevel1Code:
+      maxLength: 4
+      minLength: 1
+      enum:
+      - SEPA
+      - SRTP
+      type: string
+    ExternalStatusReason1Code:
+      maxLength: 4
+      minLength: 1
+      enum:
+      - AC02
+      - AM03
+      - AM05
+      - ATNS
+      - BE16
+      - CNNS
+      - EDTL
+      - EDTR
+      - FF01
+      - FRAD
+      - INAR
+      - IPNS
+      - MS03
+      - NRCH
+      - PINS
+      - RR04
+      - RTNS
+      - SPII
+      - UCRD
+      type: string
+    ExternalStatusReason1Code_II:
+      maxLength: 4
+      minLength: 1
+      enum:
+      - AM03
+      - AM05
+      - AM09
+      - EDNA
+      - FRAD
+      - IEDT
+      - MS02
+      - NOAR
+      - UCRD
+      type: string
+    ExternalStatusReason1Code_III:
+      maxLength: 4
+      minLength: 1
+      enum: 
+      - AEXR
+      - ALAC
+      - ARFR
+      - ARJR
+      - IRNR
+      - REPR
+      type: string
+    FinancialIdentificationSchemeName1Choice:
+      oneOf:
+      - $ref: '#/components/schemas/ExternalFinancialInstitutionIdentification1Code_Wrapper'
+      - $ref: '#/components/schemas/Max35Text_Wrapper'
+    GenericOrganisationIdentification1:
+      type: object
+      properties:
+        Id:
+          $ref: '#/components/schemas/Max35Text'
+        SchmeNm:
+          $ref: '#/components/schemas/OrganisationIdentificationSchemeName1Choice'
+        Issr:
+          $ref: '#/components/schemas/Max35Text'
+      required:
+      - Id
+    GenericOrganisationIdentification1_EPC259-22_V4.0_DS02:
+      type: object
+      properties:
+        Id:
+          $ref: '#/components/schemas/Max35Text'
+        SchmeNm:
+          $ref: '#/components/schemas/OrganisationIdentificationSchemeName1Choice_EPC259-22_V4.0_DS02'
+      required:
+      - Id
+      - SchmeNm
+    GenericOrganisationIdentification1_EPC259-22_V4.0_DS04b:
+      type: object
+      properties:
+        Id:
+          $ref: '#/components/schemas/Max35Text'
+        SchmeNm:
+          $ref: '#/components/schemas/OrganisationIdentificationSchemeName1Choice_EPC259-22_V4.0_DS04b'
+        Issr:
+          $ref: '#/components/schemas/Max35Text'
+      required:
+      - Id
+    GenericPersonIdentification1:
+      type: object
+      properties:
+        Id:
+          $ref: '#/components/schemas/Max35Text'
+        SchmeNm:
+          $ref: '#/components/schemas/PersonIdentificationSchemeName1Choice'
+        Issr:
+          $ref: '#/components/schemas/Max35Text'
+      required:
+      - Id
+    GenericPersonIdentification1_EPC259-22_V4.0_DS02:
+      type: object
+      properties:
+        Id:
+          $ref: '#/components/schemas/Max35Text'
+        SchmeNm:
+          $ref: '#/components/schemas/PersonIdentificationSchemeName1Choice_EPC259-22_V4.0_DS02'
+      required:
+      - Id
+    GenericPersonIdentification1_II:
+      type: object
+      properties:
+        Id:
+          $ref: '#/components/schemas/Max35Text'
+        SchmeNm:
+          $ref: '#/components/schemas/PersonIdentificationSchemeName1Choice_II'
+        Issr:
+          $ref: '#/components/schemas/Max35Text'
+      required:
+      - Id
+    Max34Text:
+      maxLength: 34
+      minLength: 1
+      type: string
+    OrganisationIdentification29_EPC259-22_V4.0_DS02_2:
+      type: object
+      properties:
+        AnyBIC:
+          $ref: '#/components/schemas/AnyBICDec2014Identifier'
+        LEI:
+          $ref: '#/components/schemas/LEIIdentifier'
+        Othr:
+          type: array
+          items:
+            $ref: '#/components/schemas/GenericOrganisationIdentification1_EPC259-22_V4.0_DS02_2'
+          maxItems: 3
+    Party38Choice_EPC259-22_V4.0_DS04b_2:
+      oneOf:
+      - $ref: '#/components/schemas/OrganisationIdentification29_EPC259-22_V4.0_DS04b_2_Wrapper'
+      - $ref: '#/components/schemas/PersonIdentification13_IV_Wrapper'
+    Party38Choice_EPC259-22_V4.0_DS15RTP:
+      oneOf:
+      - $ref: '#/components/schemas/OrganisationIdentification29_EPC259-22_V4.0_DS15RTP_Wrapper'
+      - $ref: '#/components/schemas/PersonIdentification13_EPC259-22_V4.0_DS15RTP_Wrapper'
+    Party40Choice_EPC259-22_V4.0_DS11_3:
+      oneOf:
+      - $ref: '#/components/schemas/PartyIdentification135_EPC259-22_V4.0_DS04b_3_Wrapper'
+    PartyIdentification135_EPC259-22_V4.0_DS11_3:
+      type: object
+      properties:
+        Nm:
+          $ref: '#/components/schemas/Max140Text_CreditorName_DS11'
+        Id:
+          $ref: '#/components/schemas/Party38Choice_EPC259-22_V4.0_DS11_3'
+    PartyIdentification135_EPC259-22_V4.0_DS15RFC_3:
+      type: object
+      properties:
+        Nm:
+          allOf:
+            - $ref: '#/components/schemas/Max140Text_CreditorName_DSXX_2'
+            - description: |
+                SEPA Usage Rule: 
+                - For a natural person, the first and last name must be provided.
+        Id:
+          $ref: '#/components/schemas/Party38Choice_EPC259-22_V4.0_DS11_3'
+      required:
+      - Id
+    PartyIdentification135_II:
+      type: object
+      properties:
+        Nm:
+          $ref: '#/components/schemas/Max140Text'
+        PstlAdr:
+          $ref: '#/components/schemas/PostalAddress24'
+        Id:
+          $ref: '#/components/schemas/Party38Choice'
+        CtryOfRes:
+          $ref: '#/components/schemas/CountryCode'
+        CtctDtls:
+          $ref: '#/components/schemas/Contact4'
+    PersonIdentification13_EPC259-22_V4.0_DS02_2:
+      type: object
+      properties:
+        Othr:
+          type: array
+          items:
+            $ref: '#/components/schemas/GenericPersonIdentification1_EPC259-22_V4.0_DS02_2'
+          maxItems: 2
+    PersonIdentification13_IV:
+      type: object
+      properties:
+        Othr:
+          $ref: '#/components/schemas/GenericPersonIdentification1_IV'
+      required:
+      - Othr
+    ProxyAccountIdentification1_EPC259-22_V4.0_DS08N:
+      type: object
+      properties:
+        Tp:
+          $ref: '#/components/schemas/ProxyAccountType1Choice_EPC259-22_V4.0_DS08N'
+        Id:
+          $ref: '#/components/schemas/Max320Text'
+      required:
+      - Id
+    RemittanceAmount2_EPC259-22_V4.0_DS02:
+      type: object
+      properties:
+        CdtNoteAmt:
+          $ref: '#/components/schemas/ActiveOrHistoricCurrencyAndAmount_EPC259-22_V4.0_DS02_2'
+      required:
+      - CdtNoteAmt
+    RemittanceAmount2_EPC259-22_V4.0_DS15RTP:
+      type: object
+      description: |
+        SEPA Rulebook Reference:
+        - AT-T019 Credit Note Amount.
+        SEPA Usage Rule:
+        - Mandatory, if provided in DS-02.
+      properties:
+        CdtNoteAmt:
+          $ref: '#/components/schemas/ActiveOrHistoricCurrencyAndAmount_EPC259-22_V4.0_DS02_2'
+      required:
+      - CdtNoteAmt   
+    RemittanceInformation16:
+      type: object
+      properties:
+        Ustrd:
+          $ref: '#/components/schemas/Max140Text'
+        Strd:
+          $ref: '#/components/schemas/StructuredRemittanceInformation16'
+    RemittanceLocationMethod2Code:
+      enum:
+      - URID
+      type: string
+    SkipPayload:
+      type: object
+      properties:
+        any: {}
+      required:
+      - any
+    StructuredRemittanceInformation16_EPC259-22_V4.0_DS04b:
+      type: object
+      properties:
+        RfrdDocAmt:
+          $ref: '#/components/schemas/RemittanceAmount2_EPC259-22_V4.0_DS02'
+        CdtrRefInf:
+          $ref: '#/components/schemas/CreditorReferenceInformation2_EPC259-22_V4.0_DS02'
+    ActiveOrHistoricCurrencyAndAmount_EPC259-22_V4.0_DS02_2:
+      maximum: 999999999.99
+      minimum: 0.01
+      type: number
+    Contact4:
+      type: object
+      properties:
+        NmPrfx:
+          $ref: '#/components/schemas/NamePrefix2Code'
+        Nm:
+          $ref: '#/components/schemas/Max140Text'
+        PhneNb:
+          $ref: '#/components/schemas/PhoneNumber'
+        MobNb:
+          $ref: '#/components/schemas/PhoneNumber'
+        FaxNb:
+          $ref: '#/components/schemas/PhoneNumber'
+        EmailAdr:
+          $ref: '#/components/schemas/Max2048Text'
+        EmailPurp:
+          $ref: '#/components/schemas/Max35Text'
+        JobTitl:
+          $ref: '#/components/schemas/Max35Text'
+        Rspnsblty:
+          $ref: '#/components/schemas/Max35Text'
+        Dept:
+          $ref: '#/components/schemas/Max70Text'
+        Othr:
+          type: array
+          items:
+            $ref: '#/components/schemas/OtherContact1'
+        PrefrdMtd:
+          $ref: '#/components/schemas/PreferredContactMethod1Code'
+    CreditorReferenceType2_EPC259-22_V4.0_DS02:
+      type: object
+      properties:
+        CdOrPrtry:
+          $ref: '#/components/schemas/CreditorReferenceType1Choice_EPC259-22_V4.0_DS02'
+        Issr:
+          $ref: '#/components/schemas/Max35Text'
+      required:
+      - CdOrPrtry
+    ExternalAccountIdentification1Code:
+      maxLength: 4
+      minLength: 1
+      type: string
+    ExternalCancellationReason1Code:
+      maxLength: 4
+      minLength: 1
+      enum:
+      - AC02
+      - AM09
+      - BE16
+      - DRTP
+      - DT01
+      - FRAD
+      - MODT
+      - PAID
+      - TECH
+      type: string
+    ExternalFinancialInstitutionIdentification1Code:
+      maxLength: 4
+      minLength: 1
+      type: string
+    GenericAccountIdentification1_EPC259-22_V4.0_DS08N:
+      type: object
+      properties:
+        Id:
+          $ref: '#/components/schemas/Max34Text'
+        SchmeNm:
+          $ref: '#/components/schemas/AccountSchemeName1Choice_EPC259-22_V4.0_DS08N'
+        Issr:
+          $ref: '#/components/schemas/Max35Text'
+      required:
+      - Id
+    GenericOrganisationIdentification1_EPC259-22_V4.0_DS02_2:
+      type: object
+      properties:
+        Id:
+          $ref: '#/components/schemas/Max35Text'
+        SchmeNm:
+          $ref: '#/components/schemas/OrganisationIdentificationSchemeName1Choice_EPC259-22_V4.0_DS02_2'
+      required:
+      - Id
+      - SchmeNm
+    GenericPersonIdentification1_EPC259-22_V4.0_DS02_2:
+      type: object
+      properties:
+        Id:
+          $ref: '#/components/schemas/Max35Text'
+        SchmeNm:
+          $ref: '#/components/schemas/PersonIdentificationSchemeName1Choice_EPC259-22_V4.0_DS02'
+      required:
+      - Id
+      - SchmeNm
+    GenericPersonIdentification1_IV:
+      type: object
+      properties:
+        Id:
+          $ref: '#/components/schemas/Max35Text'
+        SchmeNm:
+          $ref: '#/components/schemas/PersonIdentificationSchemeName1Choice_IV'
+      required:
+      - Id
+      - SchmeNm
+    OrganisationIdentification29_EPC259-22_V4.0_DS04b_2:
+      type: object
+      properties:
+        AnyBIC:
+          $ref: '#/components/schemas/AnyBICDec2014Identifier'
+        LEI:
+          $ref: '#/components/schemas/LEIIdentifier'
+        Othr:
+          $ref: '#/components/schemas/GenericOrganisationIdentification1_EPC259-22_V4.0_DS04b_2'
+    OrganisationIdentification29_EPC259-22_V4.0_DS15RTP:
+      type: object
+      properties:
+        AnyBIC:
+          $ref: '#/components/schemas/AnyBICDec2014Identifier'
+        LEI:
+          $ref: '#/components/schemas/LEIIdentifier'
+        Othr:
+          $ref: '#/components/schemas/GenericOrganisationIdentification1_EPC259-22_V4.0_DS15RTP'
+    OrganisationIdentificationSchemeName1Choice:
+      oneOf:
+      - $ref: '#/components/schemas/ExternalOrganisationIdentification1Code_Wrapper'
+      - $ref: '#/components/schemas/Max35Text_Wrapper'
+    OrganisationIdentificationSchemeName1Choice_EPC259-22_V4.0_DS02:
+      oneOf:
+      - $ref: '#/components/schemas/ExternalOrganisationIdentification1Code_EPC259-22_V4.0_DS02_Wrapper'
+      - $ref: '#/components/schemas/Max35Text_EPC259-22_V4.0_DS02_Wrapper'
+    OrganisationIdentificationSchemeName1Choice_EPC259-22_V4.0_DS04b:
+      oneOf:
+      - $ref: '#/components/schemas/ExternalOrganisationIdentification1Code_II_Wrapper'
+      - $ref: '#/components/schemas/Max35Text_Wrapper'
+    Party38Choice_EPC259-22_V4.0_DS11_3:
+      oneOf:
+      - $ref: '#/components/schemas/OrganisationIdentification29_EPC259-22_V4.0_DS11_2_Wrapper'
+      - $ref: '#/components/schemas/PersonIdentification13_IV_Wrapper'
+    PersonIdentification13_EPC259-22_V4.0_DS15RTP:
+      type: object
+      properties:
+        Othr:
+          $ref: '#/components/schemas/GenericPersonIdentification1_EPC259-22_V4.0_DS15RTP'
+      required:
+      - Othr
+    PersonIdentificationSchemeName1Choice:
+      oneOf:
+      - $ref: '#/components/schemas/ExternalPersonIdentification1Code_Wrapper'
+      - $ref: '#/components/schemas/Max35Text_Wrapper'
+    PersonIdentificationSchemeName1Choice_EPC259-22_V4.0_DS02:
+      oneOf:
+      - $ref: '#/components/schemas/ExternalPersonIdentification1Code_EPC259-22_V4.0_DS02_Wrapper'
+      - $ref: '#/components/schemas/Max35Text_EPC259-22_V4.0_DS02_2_Wrapper'
+    PersonIdentificationSchemeName1Choice_II:
+      oneOf:
+      - $ref: '#/components/schemas/ExternalPersonIdentification1Code_II_Wrapper'
+      - $ref: '#/components/schemas/Max35Text_Wrapper'
+    PostalAddress24:
+      type: object
+      properties:
+        AdrTp:
+          $ref: '#/components/schemas/AddressType3Choice'
+        Dept:
+          $ref: '#/components/schemas/Max70Text'
+        SubDept:
+          $ref: '#/components/schemas/Max70Text'
+        StrtNm:
+          $ref: '#/components/schemas/Max70Text'
+        BldgNb:
+          $ref: '#/components/schemas/Max16Text'
+        BldgNm:
+          $ref: '#/components/schemas/Max35Text'
+        Flr:
+          $ref: '#/components/schemas/Max70Text'
+        PstBx:
+          $ref: '#/components/schemas/Max16Text'
+        Room:
+          $ref: '#/components/schemas/Max70Text'
+        PstCd:
+          $ref: '#/components/schemas/Max16Text'
+        TwnNm:
+          $ref: '#/components/schemas/Max35Text'
+        TwnLctnNm:
+          $ref: '#/components/schemas/Max35Text'
+        DstrctNm:
+          $ref: '#/components/schemas/Max35Text'
+        CtrySubDvsn:
+          $ref: '#/components/schemas/Max35Text'
+        Ctry:
+          $ref: '#/components/schemas/CountryCode'
+        AdrLine:
+          type: array
+          items:
+            $ref: '#/components/schemas/Max70Text'
+          maxItems: 7
+    ProxyAccountType1Choice_EPC259-22_V4.0_DS08N:
+      oneOf:
+      - $ref: '#/components/schemas/ExternalProxyAccountType1Code_II_Wrapper'
+      - $ref: '#/components/schemas/Max35Text_Wrapper'
+    StructuredRemittanceInformation16:
+      type: object
+      properties:
+        RfrdDocAmt:
+          $ref: '#/components/schemas/RemittanceAmount2'
+        CdtrRefInf:
+          $ref: '#/components/schemas/CreditorReferenceInformation2_EPC259-22_V4.0_DS02'
+    AccountSchemeName1Choice_EPC259-22_V4.0_DS08N:
+      oneOf:
+      - $ref: '#/components/schemas/ExternalAccountIdentification1Code_II_Wrapper'
+      - $ref: '#/components/schemas/Max35Text_Wrapper'
+    AddressType3Choice:
+      oneOf:
+      - $ref: '#/components/schemas/AddressType2Code_Wrapper'
+      - $ref: '#/components/schemas/GenericIdentification30_Wrapper'
+    CreditorReferenceType1Choice_EPC259-22_V4.0_DS02:
+      oneOf:
+      - $ref: '#/components/schemas/DocumentType3Code_Wrapper'
+    ExternalOrganisationIdentification1Code:
+      maxLength: 4
+      minLength: 1
+      type: string
+    ExternalOrganisationIdentification1Code_EPC259-22_V4.0_DS02:
+      maxLength: 4
+      minLength: 1
+      enum:
+      - BOID
+      type: string
+    ExternalOrganisationIdentification1Code_II:
+      maxLength: 4
+      minLength: 1
+      enum:
+      - BANK
+      - BDID
+      - BOID
+      - CBID
+      - CHID
+      - CINC
+      - COID
+      - CUST
+      - DUNS
+      - EMPL
+      - GS1G
+      - SREN
+      - SRET
+      - TXID
+      type: string
+    ExternalPersonIdentification1Code:
+      maxLength: 4
+      minLength: 1
+      type: string
+    ExternalPersonIdentification1Code_EPC259-22_V4.0_DS02:
+      maxLength: 4
+      minLength: 1
+      enum:
+      - POID
+      type: string
+    ExternalPersonIdentification1Code_II:
+      maxLength: 4
+      minLength: 1
+      enum:
+      - ARNU
+      - CCPT
+      - CUST
+      - DRLC
+      - EMPL
+      - NIDN
+      - POID
+      - SOSE
+      - TELE
+      - TXID
+      type: string
+    ExternalProxyAccountType1Code_II:
+      maxLength: 4
+      minLength: 1
+      enum:
+      - BIID
+      - CCPT
+      - CINC
+      - COID
+      - COTX
+      - CUST
+      - DNAM
+      - DRLC
+      - EIDN
+      - EMAL
+      - EWAL
+      - LEIC
+      - MBNO
+      - NIDN
+      - PVTX
+      - SHID
+      - SOSE
+      - TELE
+      - TOKN
+      - UBIL
+      - VIPN
+      type: string
+    GenericOrganisationIdentification1_EPC259-22_V4.0_DS04b_2:
+      type: object
+      properties:
+        Id:
+          $ref: '#/components/schemas/Max35Text'
+        SchmeNm:
+          $ref: '#/components/schemas/OrganisationIdentificationSchemeName1Choice_EPC259-22_V4.0_DS04b_2'
+      required:
+      - Id
+      - SchmeNm
+    GenericOrganisationIdentification1_EPC259-22_V4.0_DS15RTP:
+      type: object
+      properties:
+        Id:
+          $ref: '#/components/schemas/Max35Text'
+        SchmeNm:
+          $ref: '#/components/schemas/OrganisationIdentificationSchemeName1Choice_EPC259-22_V4.0_DS16RTP_2'
+      required:
+      - Id
+      - SchmeNm
+    GenericPersonIdentification1_EPC259-22_V4.0_DS15RTP:
+      type: object
+      properties:
+        Id:
+          $ref: '#/components/schemas/Max35Text'
+        SchmeNm:
+          $ref: '#/components/schemas/PersonIdentificationSchemeName1Choice_V'
+      required:
+      - Id
+      - SchmeNm
+    Max16Text:
+      maxLength: 16
+      minLength: 1
+      type: string
+    Max35Text_EPC259-22_V4.0_DS02:
+      maxLength: 35
+      minLength: 1
+      enum:
+      - BCID
+      type: string
+    Max35Text_EPC259-22_V4.0_DS02_2:
+      maxLength: 35
+      minLength: 1
+      enum:
+      - PCID
+      type: string
+    NamePrefix2Code:
+      enum:
+      - DOCT
+      - MADM
+      - MIKS
+      - MISS
+      - MIST
+      type: string
+    OrganisationIdentification29_EPC259-22_V4.0_DS11_2:
+      type: object
+      properties:
+        AnyBIC:
+          $ref: '#/components/schemas/AnyBICDec2014Identifier'
+        LEI:
+          $ref: '#/components/schemas/LEIIdentifier'
+        Othr:
+          $ref: '#/components/schemas/GenericOrganisationIdentification1_EPC259-22_V4.0_DS11_2'
+    OrganisationIdentificationSchemeName1Choice_EPC259-22_V4.0_DS02_2:
+      oneOf:
+      - $ref: '#/components/schemas/ExternalOrganisationIdentification1Code_EPC259-22_V4.0_DS02_2_Wrapper'
+      - $ref: '#/components/schemas/Max35Text_EPC259-22_V4.0_DS02_Wrapper'
+    OtherContact1:
+      type: object
+      properties:
+        ChanlTp:
+          $ref: '#/components/schemas/Max4Text'
+        Id:
+          $ref: '#/components/schemas/Max128Text'
+      required:
+      - ChanlTp
+    PersonIdentificationSchemeName1Choice_IV:
+      oneOf:
+      - $ref: '#/components/schemas/ExternalPersonIdentification1Code_EPC259-22_V4.0_DS02_Wrapper'
+    PhoneNumber:
+      pattern: \+[0-9]{1,3}-[0-9()+\-]{1,30}
+      type: string
+    PreferredContactMethod1Code:
+      enum:
+      - CELL
+      - FAXX
+      - LETT
+      - MAIL
+      - PHON
+      type: string
+    RemittanceAmount2:
+      type: object
+      properties:
+        CdtNoteAmt:
+          $ref: '#/components/schemas/ActiveOrHistoricCurrencyAndAmount_EPC259-22_V4.0_DS02'
+      required:
+      - CdtNoteAmt   
+    AddressType2Code:
+      enum:
+      - ADDR
+      - BIZZ
+      - DLVY
+      - HOME
+      - MLTO
+      - PBOX
+      type: string
+    DocumentType3Code:
+      enum:
+      - SCOR
+      type: string
+    ExternalAccountIdentification1Code_II:
+      maxLength: 4
+      minLength: 1
+      enum:
+      - AIIN
+      - BBAN
+      - CUID
+      - UPIC
+      type: string
+    ExternalOrganisationIdentification1Code_EPC259-22_V4.0_DS02_2:
+      maxLength: 4
+      minLength: 1
+      enum:
+      - BDID
+      - BOID
+      type: string
+    GenericIdentification30:
+      type: object
+      properties:
+        Id:
+          $ref: '#/components/schemas/Exact4AlphaNumericText'
+        Issr:
+          $ref: '#/components/schemas/Max35Text'
+        SchmeNm:
+          $ref: '#/components/schemas/Max35Text'
+      required:
+      - Id
+      - Issr
+    GenericOrganisationIdentification1_EPC259-22_V4.0_DS11_2:
+      type: object
+      properties:
+        Id:
+          $ref: '#/components/schemas/Max35Text'
+        SchmeNm:
+          $ref: '#/components/schemas/OrganisationIdentificationSchemeName1Choice_EPC259-22_V4.0_DS04b_2'
+        Issr:
+          $ref: '#/components/schemas/Max35Text'
+      required:
+      - Id
+    Max128Text:
+      maxLength: 128
+      minLength: 1
+      type: string
+    Max4Text:
+      maxLength: 4
+      minLength: 1
+      type: string
+    OrganisationIdentificationSchemeName1Choice_EPC259-22_V4.0_DS04b_2:
+      oneOf:
+      - $ref: '#/components/schemas/ExternalOrganisationIdentification1Code_EPC259-22_V4.0_DS02_Wrapper'
+    OrganisationIdentificationSchemeName1Choice_EPC259-22_V4.0_DS16RTP_2:
+      oneOf:
+      - $ref: '#/components/schemas/ExternalOrganisationIdentification1Code_II_Wrapper'
+    PersonIdentificationSchemeName1Choice_V:
+      oneOf:
+      - $ref: '#/components/schemas/ExternalPersonIdentification1Code_II_Wrapper'
+    Exact4AlphaNumericText:
+      pattern: '[a-zA-Z0-9]{4}'
+      type: string
+    YesNoIndicator_Wrapper:
+      type: object
+      properties:
+        AssgnmtCxlConf:
+          $ref: '#/components/schemas/YesNoIndicator'
+    ISODate_Wrapper:
+      type: object
+      properties:
+        Dt:
+          $ref: '#/components/schemas/ISODate'
+    ISODateTime_Wrapper:
+      type: object
+      properties:
+        DtTm:
+          $ref: '#/components/schemas/UtcIsoDateTimeWithMilliseconds'
+    ExternalInvestigationExecutionConfirmation1Code_Wrapper:
+      type: object
+      properties:
+        Conf:
+          $ref: '#/components/schemas/ExternalInvestigationExecutionConfirmation1Code'
+    ExternalInvestigationExecutionConfirmation1Code_II_Wrapper:
+      type: object
+      properties:
+        Conf:
+          $ref: '#/components/schemas/ExternalInvestigationExecutionConfirmation1Code_II'
+    PartyIdentification135_EPC259-22_V4.0_DS04b_Wrapper:
+      type: object
+      properties:
+        Pty:
+          $ref: '#/components/schemas/PartyIdentification135_EPC259-22_V4.0_DS04b'
+    BranchAndFinancialInstitutionIdentification6_EPC259-22_V4.0_DS02_Wrapper:
+      type: object
+      properties:
+        Agt:
+          $ref: '#/components/schemas/BranchAndFinancialInstitutionIdentification6_EPC259-22_V4.0_DS02'
+    IBAN2007Identifier_Wrapper:
+      type: object
+      properties:
+        IBAN:
+          $ref: '#/components/schemas/IBAN2007Identifier'
+    GenericAccountIdentification1_EPC259-22_V4.0_DS02_Wrapper:
+      type: object
+      properties:
+        Othr:
+          $ref: '#/components/schemas/GenericAccountIdentification1_EPC259-22_V4.0_DS02'
+    AdviceType1Code_Wrapper:
+      type: object
+      properties:
+        Cd:
+          $ref: '#/components/schemas/AdviceType1Code'
+    Max35Text_Wrapper:
+      type: object
+      properties:
+        Prtry:
+          $ref: '#/components/schemas/Max35Text'
+    Max35Text_URLN_Reason_DS04b_Prtry:
+      type: string
+      maxLength: 35
+      minLength: 1 
+      enum:
+        - "URLN/ATS010"
+      description: |
+       SEPA Usage Rule:
+        Only "URLN/ATS010" (URL to the Payer not supported) is allowed,
+        in case “ATS010/ URL” was included in DS-01.
+    ActiveOrHistoricCurrencyAndAmount_EPC259-22_V4.0_DS02_Wrapper:
+      type: object
+      properties:
+        InstdAmt:
+          $ref: '#/components/schemas/ActiveOrHistoricCurrencyAndAmount_EPC259-22_V4.0_DS02'
+    OrganisationIdentification29_Wrapper:
+      type: object
+      properties:
+        OrgId:
+          $ref: '#/components/schemas/OrganisationIdentification29'
+    PersonIdentification13_Wrapper:
+      type: object
+      properties:
+        PrvtId:
+          $ref: '#/components/schemas/PersonIdentification13'
+    OrganisationIdentification29_EPC259-22_V4.0_DS02_Wrapper:
+      type: object
+      properties:
+        OrgId:
+          $ref: '#/components/schemas/OrganisationIdentification29_EPC259-22_V4.0_DS02'
+    PersonIdentification13_EPC259-22_V4.0_DS02_Wrapper:
+      type: object
+      properties:
+        PrvtId:
+          $ref: '#/components/schemas/PersonIdentification13_EPC259-22_V4.0_DS02'
+    OrganisationIdentification29_EPC259-22_V4.0_DS04b_Wrapper:
+      type: object
+      properties:
+        OrgId:
+          $ref: '#/components/schemas/OrganisationIdentification29_EPC259-22_V4.0_DS04b'
+    OrganisationIdentification29_II_Wrapper:
+      type: object
+      properties:
+        OrgId:
+          $ref: '#/components/schemas/OrganisationIdentification29_II'
+    PersonIdentification13_II_Wrapper:
+      type: object
+      properties:
+        PrvtId:
+          $ref: '#/components/schemas/PersonIdentification13_II'
+    PartyIdentification135_EPC259-22_V4.0_DS15RTP_Wrapper:
+      type: object
+      properties:
+        Pty:
+          $ref: '#/components/schemas/PartyIdentification135_EPC259-22_V4.0_DS15RTP'
+    ExternalPurpose1Code_Wrapper:
+      type: object
+      properties:
+        Cd:
+          $ref: '#/components/schemas/ExternalPurpose1Code'
+    ExternalPaymentCancellationRejection1Code_Wrapper:
+      type: object
+      properties:
+        Cd:
+          $ref: '#/components/schemas/ExternalPaymentCancellationRejection1Code'
+    ExternalCategoryPurpose1Code_Wrapper:
+      type: object
+      properties:
+        Cd:
+          $ref: '#/components/schemas/ExternalCategoryPurpose1Code'
+    ExternalDocumentFormat1Code_Wrapper:
+      type: object
+      properties:
+        Cd:
+          $ref: '#/components/schemas/ExternalDocumentFormat1Code'
+    ExternalDocumentType1Code_Wrapper:
+      type: object
+      properties:
+        Cd:
+          $ref: '#/components/schemas/ExternalDocumentType1Code'
+    ExternalLocalInstrument1Code_Wrapper:
+      type: object
+      properties:
+        Cd:
+          $ref: '#/components/schemas/ExternalLocalInstrument1Code'
+    OrganisationIdentification29_EPC259-22_V4.0_DS02_2_Wrapper:
+      type: object
+      properties:
+        OrgId:
+          $ref: '#/components/schemas/OrganisationIdentification29_EPC259-22_V4.0_DS02_2'
+    PersonIdentification13_EPC259-22_V4.0_DS02_2_Wrapper:
+      type: object
+      properties:
+        PrvtId:
+          $ref: '#/components/schemas/PersonIdentification13_EPC259-22_V4.0_DS02_2'
+    PersonIdentification13_IV_Wrapper:
+      type: object
+      properties:
+        PrvtId:
+          $ref: '#/components/schemas/PersonIdentification13_IV'
+    ExternalProxyAccountType1Code_Wrapper:
+      type: object
+      properties:
+        Cd:
+          $ref: '#/components/schemas/ExternalProxyAccountType1Code'
+    ExternalServiceLevel1Code_Wrapper:
+      type: object
+      properties:
+        Cd:
+          $ref: '#/components/schemas/ExternalServiceLevel1Code'
+    ExternalStatusReason1Code_Wrapper:
+      type: object
+      properties:
+        Cd:
+          $ref: '#/components/schemas/ExternalStatusReason1Code'
+    ExternalStatusReason1Code_II_Wrapper:
+      type: object
+      properties:
+        Cd:
+          $ref: '#/components/schemas/ExternalStatusReason1Code_II'
+    ExternalStatusReason1Code_III_Wrapper:
+      type: object
+      properties:
+        Cd:
+          $ref: '#/components/schemas/ExternalStatusReason1Code_III'
+    GenericAccountIdentification1_EPC259-22_V4.0_DS08N_Wrapper:
+      type: object
+      properties:
+        Othr:
+          $ref: '#/components/schemas/GenericAccountIdentification1_EPC259-22_V4.0_DS08N'
+    ExternalAccountIdentification1Code_Wrapper:
+      type: object
+      properties:
+        Cd:
+          $ref: '#/components/schemas/ExternalAccountIdentification1Code'
+    ExternalCancellationReason1Code_Wrapper:
+      type: object
+      properties:
+        Cd:
+          $ref: '#/components/schemas/ExternalCancellationReason1Code'
+    ExternalPaymentCancellationRejection1Code_II_Wrapper:
+      type: object
+      properties:
+        Cd:
+          $ref: '#/components/schemas/ExternalPaymentCancellationRejection1Code_II'
+    ExternalFinancialInstitutionIdentification1Code_Wrapper:
+      type: object
+      properties:
+        Cd:
+          $ref: '#/components/schemas/ExternalFinancialInstitutionIdentification1Code'
+    OrganisationIdentification29_EPC259-22_V4.0_DS04b_2_Wrapper:
+      type: object
+      properties:
+        OrgId:
+          $ref: '#/components/schemas/OrganisationIdentification29_EPC259-22_V4.0_DS04b_2'
+    OrganisationIdentification29_EPC259-22_V4.0_DS15RTP_Wrapper:
+      type: object
+      properties:
+        OrgId:
+          $ref: '#/components/schemas/OrganisationIdentification29_EPC259-22_V4.0_DS15RTP'
+    PersonIdentification13_EPC259-22_V4.0_DS15RTP_Wrapper:
+      type: object
+      properties:
+        PrvtId:
+          $ref: '#/components/schemas/PersonIdentification13_EPC259-22_V4.0_DS15RTP'
+    PartyIdentification135_EPC259-22_V4.0_DS04b_3_Wrapper:
+      type: object
+      properties:
+        Pty:
+          $ref: '#/components/schemas/PartyIdentification135_EPC259-22_V4.0_DS04b_3'
+    ExternalOrganisationIdentification1Code_Wrapper:
+      type: object
+      properties:
+        Cd:
+          $ref: '#/components/schemas/ExternalOrganisationIdentification1Code'
+    ExternalOrganisationIdentification1Code_EPC259-22_V4.0_DS02_Wrapper:
+      type: object
+      properties:
+        Cd:
+          $ref: '#/components/schemas/ExternalOrganisationIdentification1Code_EPC259-22_V4.0_DS02'
+    Max35Text_EPC259-22_V4.0_DS02_Wrapper:
+      type: object
+      properties:
+        Prtry:
+          $ref: '#/components/schemas/Max35Text_EPC259-22_V4.0_DS02'
+    ExternalOrganisationIdentification1Code_II_Wrapper:
+      type: object
+      properties:
+        Cd:
+          $ref: '#/components/schemas/ExternalOrganisationIdentification1Code_II'
+    OrganisationIdentification29_EPC259-22_V4.0_DS11_2_Wrapper:
+      type: object
+      properties:
+        OrgId:
+          $ref: '#/components/schemas/OrganisationIdentification29_EPC259-22_V4.0_DS11_2'
+    ExternalPersonIdentification1Code_Wrapper:
+      type: object
+      properties:
+        Cd:
+          $ref: '#/components/schemas/ExternalPersonIdentification1Code'
+    ExternalPersonIdentification1Code_EPC259-22_V4.0_DS02_Wrapper:
+      type: object
+      properties:
+        Cd:
+          $ref: '#/components/schemas/ExternalPersonIdentification1Code_EPC259-22_V4.0_DS02'
+    Max35Text_EPC259-22_V4.0_DS02_2_Wrapper:
+      type: object
+      properties:
+        Prtry:
+          $ref: '#/components/schemas/Max35Text_EPC259-22_V4.0_DS02_2'
+    ExternalPersonIdentification1Code_II_Wrapper:
+      type: object
+      properties:
+        Cd:
+          $ref: '#/components/schemas/ExternalPersonIdentification1Code_II'
+    ExternalProxyAccountType1Code_II_Wrapper:
+      type: object
+      properties:
+        Cd:
+          $ref: '#/components/schemas/ExternalProxyAccountType1Code_II'
+    ExternalAccountIdentification1Code_II_Wrapper:
+      type: object
+      properties:
+        Cd:
+          $ref: '#/components/schemas/ExternalAccountIdentification1Code_II'
+    AddressType2Code_Wrapper:
+      type: object
+      properties:
+        Cd:
+          $ref: '#/components/schemas/AddressType2Code'
+    GenericIdentification30_Wrapper:
+      type: object
+      properties:
+        Prtry:
+          $ref: '#/components/schemas/GenericIdentification30'
+    DocumentType3Code_Wrapper:
+      type: object
+      properties:
+        Cd:
+          $ref: '#/components/schemas/DocumentType3Code'
+    ExternalOrganisationIdentification1Code_EPC259-22_V4.0_DS02_2_Wrapper:
+      type: object
+      properties:
+        Cd:
+          $ref: '#/components/schemas/ExternalOrganisationIdentification1Code_EPC259-22_V4.0_DS02_2'
+    UtcIsoDateTimeWithMilliseconds:
+      type: string
+      format: date-time
+      pattern: '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}(Z|([+-]\d{2}:\d{2}))$'
+      description: >
+          ISO 8601 date-time with milliseconds and mandatory UTC ('Z') or UTC offset.
+          SEPA Usage Rule:
+            - Timestamps must be unambiguous and include milliseconds.
+            - Only UTC time format ('Z') or local time with UTC offset format are allowed.
+            - The representation of milliseconds must follow the W3C recommendation (format: YYYY-MM-DDTHH:MM:SS.sssZ).
+            Example: 2025-06-12T15:30:45.123Z or 2025-06-12T15:30:45.123+02:00.
+          SEPA Rulebook Reference (for Redirect Message - DS05):
+            - AT-R116 Date and Time Stamp of the interim technical redirect message.
+    Max320Text:
+      type: string
+      maxLength: 320
+      minLength: 1
+      description: |
+          SEPA Usage Rule: 'Identification' is limited to 320 characters in length.
+          SEPA length updated to 320 (instead of 2048).
+  responses:
+    BadRequest:
+      description: The request could not be parsed or processed (HTTP400).
+      headers:
+        Correlation:
+          $ref: '#/components/headers/X-Request-ID'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorModel'
+    Unauthorized:
+      description: Indicates that the request requires user authentication information. The client MAY repeat the request with a suitable Authorization header field (HTTP401).
+      headers:
+        Correlation:
+          $ref: '#/components/headers/X-Request-ID'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorModel'
+    NotFound:
+      description: The requested resource was not found (HTTP404).
+      headers:
+        Correlation:
+          $ref: '#/components/headers/X-Request-ID'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorModel'
+    NotAcceptable:
+      description: The server doesn’t find any content that conforms to the criteria given by the user agent in the Accept header sent in the request. (HTTP406).
+      headers:
+        Correlation:
+          $ref: '#/components/headers/X-Request-ID'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorModel'
+    Conflict:
+      description: |
+        The request could not be completed due to a conflict with the current state of the resource (e.g. pre-existing resource). (HTTP409)
+
+        The location header aims to provide the location of the pre-existing resource.
+      headers:
+        location:
+          $ref: '#/components/headers/Location'
+        Correlation:
+          $ref: '#/components/headers/X-Request-ID'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorModel'
+    Gone:
+      description: |
+        The requested resource is no longer available at the server. (HTTP410)
+        For instance, the relevant SEPA Request-To-Pay has expired.
+      headers:
+        Correlation:
+          $ref: '#/components/headers/X-Request-ID'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorModel'
+    UnsupportedMediaType:
+      description: The media-type in Content-type of the request is not supported by the server. (HTTP415)
+      headers:
+        Correlation:
+          $ref: '#/components/headers/X-Request-ID'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorModel'
+    TooManyRequests:
+      description: The client has sent too many requests in a given amount of time (“rate limiting”) (HTTP429)
+      headers:
+        Correlation:
+          $ref: '#/components/headers/X-Request-ID'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorModel'
+  parameters:
+    Idempotency:
+      name: Idempotency-key
+      in: header
+      description: |
+        Idempotency key header to be used with every POST operation.
+
+        The API client for one given payload has to generate a UUID (RFC4122) et set the header value with this UUID.
+        When, for instance in the absence of response to the POST request from the API server, the API client has to retry the request, it must use the same UUID value.
+        On the other side, the API client must not reuse this UUID for posting another payload.
+
+        The API server, when receiving a POST request, must ensure that the idempotency key header is present. If not the API server must respond with a HTTP400 (BAD REQUEST) code.
+        When present, the idempotency key value must be checked against previously received idempotency key:
+        - if the value is not found, the API server shall process the request normally.
+        - if the value was already received, different situation can apply:
+          - when there is an attempt to reuse an idempotency key with a different payload, the API server must respond with an HTTP422 (UNPROCESSABLE ENTITY) code.
+          - when this is really a retry to post the same request:
+            - if the original one still being processed, the API server must respond with a HTTP409 (CONFLICT) code.
+          - if the original request processing was completed, the API server must answer with the result of this original request processing.
+
+        It is up to the API server to manage the life-cycle of the idempotency key.
+      required: true
+      deprecated: false
+      allowEmptyValue: false
+      explode: false
+      allowReserved: false
+      schema:
+        type: string
+        format: uuid
+    SepaRequestToPayRequestResourceId:
+      name: sepaRequestToPayRequestResourceId
+      in: path
+      description: Identification of the SEPA Request-To-Pay Resource
+      required: true
+      deprecated: false
+      allowEmptyValue: false
+      explode: false
+      allowReserved: false
+      schema:
+        type: string
+    SepaRequestToPayCancellationResourceId:
+      name: "sepaRequestToPayCancellationResourceId"
+      in: path
+      description: Identification of the SEPA Request-To-Pay Cancellation Request Resource
+      required: true
+      deprecated: false
+      allowEmptyValue: false
+      explode: false
+      allowReserved: false
+      schema:
+        type: string
+    Correlation:
+      name: "X-Request-ID"
+      in: header
+      description: Correlation header to be set in a request and retrieved in the relevant response
+      required: true
+      deprecated: false
+      allowEmptyValue: false
+      explode: false
+      allowReserved: false
+      schema:
+        maxLength: 70
+        type: string
+  headers:
+    Location:
+      description: |
+        URI that may point
+        * either to the resource that was successfully created by the API server after having been posgted by the API client,
+        * or to a pre-existing resource that conflicts with the one just posted by the API client.
+      required: false
+      deprecated: false
+      allowEmptyValue: false
+      explode: false
+      allowReserved: false
+      schema:
+        type: string
+        format: uri
+    X-Request-ID:
+      description: Correlation header to be set in a request and retrieved in the relevant response
+      required: false
+      deprecated: false
+      allowEmptyValue: false
+      explode: false
+      allowReserved: false
+      schema:
+        type: string

--- a/src/srtp/api/epc/EPC133-22 v1.0 SRTP API YAML V4.0.yaml
+++ b/src/srtp/api/epc/EPC133-22 v1.0 SRTP API YAML V4.0.yaml
@@ -2199,7 +2199,7 @@ components:
             Additional recommendations:
             - It is recommended to provide as many structured elements as possible.
             - These rules apply equally to Debtor and Creditor addresses.
-            - These rules must be enforced at business layer; JSON Schema cannot enforce conditional branching (Structured vs Hybrid) alone.            
+            - These rules must be enforced at business layer; JSON Schema cannot enforce conditional branching (Structured vs Hybrid) alone.
       properties:
         TwnNm:
           type: string
@@ -2245,7 +2245,7 @@ components:
         - AT-T009 RTP Remittance Information to be inserted in the payment (containing possibly AT-S002 Payee’s end-to-end reference of the RTP and AT-T019 Credit note amount*), mandatory if provided in DS-02.
         - AT-S005 Expiry Date/Time of the RTP.
         - AT-S013 Placeholder for Charges.
-        SEPA Usage Rule: 
+        SEPA Usage Rule:
         - Mandatory.
         - Both ‘Unstructured’ and ‘Structured’ can be present:
         - AT-T009 can be present either in ‘Unstructured’ or ‘Structured’ and may also contain AT-S002, and in 'Structured', also AT-T019.
@@ -2678,12 +2678,12 @@ components:
         Id:
           $ref: '#/components/schemas/Party38Choice_EPC259-22_V4.0_DS15RTP'
       required:
-      - Id    
+      - Id
     PaymentCancellationReason5_EPC259-22_V4.0_DS11:
       type: object
       properties:
         Orgtr:
-          allOf:  
+          allOf:
             - $ref: '#/components/schemas/PartyIdentification135_EPC259-22_V4.0_DS11_3'
             - description: |
                 SEPA Rulebook Reference:
@@ -2870,8 +2870,8 @@ components:
             SEPA Usage Rule:
             - Mandatory.
             - Up to two occurrences are allowed:
-            - A first mandatory occurrence starting with “ATS005/” followed by the Expiry Date/time of the RTP. 
-            - A second optional occurrence starting with “ATS013/” followed by charges related to the processing of the RTP   
+            - A first mandatory occurrence starting with “ATS005/” followed by the Expiry Date/time of the RTP.
+            - A second optional occurrence starting with “ATS013/” followed by charges related to the processing of the RTP
           items:
             $ref: '#/components/schemas/Max140Text'
           maxItems: 2
@@ -2964,7 +2964,7 @@ components:
       - ARJR
       - RR04
       - URTP
-      type: string    
+      type: string
     ExternalProxyAccountType1Code:
       maxLength: 4
       minLength: 1
@@ -3017,7 +3017,7 @@ components:
     ExternalStatusReason1Code_III:
       maxLength: 4
       minLength: 1
-      enum: 
+      enum:
       - AEXR
       - ALAC
       - ARFR
@@ -3133,7 +3133,7 @@ components:
           allOf:
             - $ref: '#/components/schemas/Max140Text_CreditorName_DSXX_2'
             - description: |
-                SEPA Usage Rule: 
+                SEPA Usage Rule:
                 - For a natural person, the first and last name must be provided.
         Id:
           $ref: '#/components/schemas/Party38Choice_EPC259-22_V4.0_DS11_3'
@@ -3194,7 +3194,7 @@ components:
         CdtNoteAmt:
           $ref: '#/components/schemas/ActiveOrHistoricCurrencyAndAmount_EPC259-22_V4.0_DS02_2'
       required:
-      - CdtNoteAmt   
+      - CdtNoteAmt
     RemittanceInformation16:
       type: object
       properties:
@@ -3613,7 +3613,7 @@ components:
         CdtNoteAmt:
           $ref: '#/components/schemas/ActiveOrHistoricCurrencyAndAmount_EPC259-22_V4.0_DS02'
       required:
-      - CdtNoteAmt   
+      - CdtNoteAmt
     AddressType2Code:
       enum:
       - ADDR
@@ -3744,7 +3744,7 @@ components:
     Max35Text_URLN_Reason_DS04b_Prtry:
       type: string
       maxLength: 35
-      minLength: 1 
+      minLength: 1
       enum:
         - "URLN/ATS010"
       description: |

--- a/src/srtp/api/test/mock_policy_epc_v4.xml
+++ b/src/srtp/api/test/mock_policy_epc_v4.xml
@@ -21,7 +21,7 @@
             ""OrgnlGrpInfAndSts"": {
             ""OrgnlMsgId"": ""TestRtpMessageKJ9283KSL01928374650"",
             ""OrgnlMsgNmId"": ""pain.013.001.07"",
-            ""OrgnlCreDtTm"": ""2026-02-12T09:30:00Z""
+            ""OrgnlCreDtTm"": ""2026-02-12T09:30:00.000Z""
             },
             ""OrgnlPmtInfAndSts"": [
             {

--- a/src/srtp/api/test/mock_policy_epc_v4.xml
+++ b/src/srtp/api/test/mock_policy_epc_v4.xml
@@ -15,7 +15,7 @@
             ""CdtrPmtActvtnReqStsRpt"": {
             ""GrpHdr"": {
             ""MsgId"": ""550e8400-e29b-41d4-a716-446655440000"",
-            ""CreDtTm"": ""2026-02-11T14:00:00Z"",
+            ""CreDtTm"": ""2026-02-11T14:00:00.000Z"","
             ""InitgPty"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP04"" } } }
             },
             ""OrgnlGrpInfAndSts"": {

--- a/src/srtp/api/test/mock_policy_epc_v4.xml
+++ b/src/srtp/api/test/mock_policy_epc_v4.xml
@@ -15,7 +15,7 @@
             ""CdtrPmtActvtnReqStsRpt"": {
             ""GrpHdr"": {
             ""MsgId"": ""550e8400-e29b-41d4-a716-446655440000"",
-            ""CreDtTm"": ""2026-02-11T14:00:00.000Z"","
+            ""CreDtTm"": ""2026-02-11T14:00:00.000Z"",
             ""InitgPty"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP04"" } } }
             },
             ""OrgnlGrpInfAndSts"": {
@@ -70,7 +70,7 @@
             ""CdtrPmtActvtnReqStsRpt"": {
             ""GrpHdr"": {
             ""MsgId"": ""990e8400-e29b-41d4-a716-446655449999"",
-            ""CreDtTm"": ""2026-02-11T14:05:00.000Z"","
+            ""CreDtTm"": ""2026-02-11T14:05:00.000Z"",
             ""InitgPty"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP04"" } } }
             },
             ""OrgnlGrpInfAndSts"": {

--- a/src/srtp/api/test/mock_policy_epc_v4.xml
+++ b/src/srtp/api/test/mock_policy_epc_v4.xml
@@ -2,7 +2,7 @@
   <inbound>
     <base />
     <choose>
-      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;QBICLE31R41A110G&quot;))">
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;DDSRSC61L26M520O&quot;))">
         <return-response>
           <set-status code="201" reason="Created" />
           <set-header name="Content-Type" exists-action="override">
@@ -57,7 +57,7 @@
             }</set-body>
         </return-response>
       </when>
-      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;LSSUDV05L25B272V&quot;))">
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;WCZQJA98L17M134D&quot;))">
         <return-response>
           <set-status code="400" reason="Bad Request" />
           <set-header name="Content-Type" exists-action="override">
@@ -115,7 +115,7 @@
             }</set-body>
         </return-response>
       </when>
-      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;RSSMRA85T10X000D&quot;))">
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;JWTGXY60H04A867N&quot;))">
         <return-response>
           <set-status code="502" reason="Bad Gateway"/>
           <set-header name="Content-Type" exists-action="override">
@@ -123,7 +123,7 @@
           </set-header>
         </return-response>
       </when>
-      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;RSSMRA80A01H501W&quot;))">
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;TXUKLK89B19A440L&quot;))">
         <return-response>
           <set-status code="201" reason="Created" />
           <set-header name="Content-Type" exists-action="override">
@@ -132,7 +132,7 @@
           <set-body template="none">"success"</set-body>
         </return-response>
       </when>
-      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;NLTJEU11T67X000L&quot;))">
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;DWNVGH98B14J906U&quot;))">
         <return-response>
           <set-status code="201" reason="Created" />
           <set-header name="Content-Type" exists-action="override">
@@ -141,7 +141,7 @@
           <set-body template="none">"6180e0d9-4d6d-4617-9dc6-a6c786395617 processed correctly"</set-body>
         </return-response>
       </when>
-      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;QPRLKI34W21X000N&quot;))">
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;LBPVHV11P26J985J&quot;))">
         <return-response>
           <set-status code="201" reason="Created" />
           <set-header name="Content-Type" exists-action="override">
@@ -150,7 +150,7 @@
           <set-body>InvalidResponse</set-body>
         </return-response>
       </when>
-      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;RPRLKI34W21X000N&quot;))">
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;XZLNHT75H27K606T&quot;))">
         <return-response>
           <set-status code="400" reason="Bad request" />
           <set-header name="Content-Type" exists-action="override">
@@ -159,7 +159,7 @@
           <set-body template="none">{"InvalidResponse"</set-body>
         </return-response>
       </when>
-      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;SPRLKI34W21X000N&quot;))">
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;GJKJDP02A27D174V&quot;))">
         <return-response>
           <set-status code="201" reason="Created" />
           <set-header name="Content-Type" exists-action="override">
@@ -168,7 +168,7 @@
           <set-body template="none">{"InvalidResponse"</set-body>
         </return-response>
       </when>
-      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;BNCLCU85M15F205W&quot;))">
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;MFNCRG01B20B521C&quot;))">
         <return-response>
           <set-status code="201" reason="Created" />
           <set-header name="Content-Type" exists-action="override">
@@ -223,7 +223,7 @@
             }</set-body>
         </return-response>
       </when>
-      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;RSSGNN92P20H501Z&quot;))">
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;CYHBXW83S01M976B&quot;))">
         <return-response>
           <set-status code="201" reason="Created" />
           <set-header name="Content-Type" exists-action="override">
@@ -279,7 +279,7 @@
             }</set-body>
         </return-response>
       </when>
-      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;DWQJHC32M47H159O&quot;))">
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;LMIMDH38M28I573U&quot;))">
         <return-response>
           <set-status code="400" reason="Bad Request" />
           <set-header name="Content-Type" exists-action="override">
@@ -338,7 +338,7 @@
             }</set-body>
         </return-response>
       </when>
-      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;NDRSCC78T31H304R&quot;))">
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;PCSRFO44D22G286S&quot;))">
         <return-response>
           <set-status code="400" reason="Bad Request" />
           <set-header name="Content-Type" exists-action="override">

--- a/src/srtp/api/test/mock_policy_epc_v4.xml
+++ b/src/srtp/api/test/mock_policy_epc_v4.xml
@@ -70,7 +70,7 @@
             ""CdtrPmtActvtnReqStsRpt"": {
             ""GrpHdr"": {
             ""MsgId"": ""990e8400-e29b-41d4-a716-446655449999"",
-            ""CreDtTm"": ""2026-02-11T14:05:00Z"",
+            ""CreDtTm"": ""2026-02-11T14:05:00.000Z"","
             ""InitgPty"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP04"" } } }
             },
             ""OrgnlGrpInfAndSts"": {

--- a/src/srtp/api/test/mock_policy_epc_v4.xml
+++ b/src/srtp/api/test/mock_policy_epc_v4.xml
@@ -1,0 +1,419 @@
+<policies>
+  <inbound>
+    <base />
+    <choose>
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;QBICLE31R41A110G&quot;))">
+        <return-response>
+          <set-status code="201" reason="Created" />
+          <set-header name="Content-Type" exists-action="override">
+            <value>application/json</value>
+          </set-header>
+          <set-body>@{
+            return @"{
+            ""resourceId"": ""TestRtpMessageA1B2C3D4E5F6G7H8"",
+            ""Document"": {
+            ""CdtrPmtActvtnReqStsRpt"": {
+            ""GrpHdr"": {
+            ""MsgId"": ""550e8400-e29b-41d4-a716-446655440000"",
+            ""CreDtTm"": ""2026-02-11T14:00:00Z"",
+            ""InitgPty"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP04"" } } }
+            },
+            ""OrgnlGrpInfAndSts"": {
+            ""OrgnlMsgId"": ""TestRtpMessageKJ9283KSL01928374650"",
+            ""OrgnlMsgNmId"": ""pain.013.001.07"",
+            ""OrgnlCreDtTm"": ""2026-02-12T09:30:00Z""
+            },
+            ""OrgnlPmtInfAndSts"": [
+            {
+            ""OrgnlPmtInfId"": ""f47ac10b-58cc-4372-a567-0e02b2c3d479"",
+            ""TxInfAndSts"": [{
+            ""StsId"": ""550e8400-e29b-41d4-a716-446655440000"",
+            ""OrgnlInstrId"": ""TestRtpMessagePL098765432109876543"",
+            ""OrgnlEndToEndId"": ""123456789012345678"",
+            ""TxSts"": ""ACTC"",
+            ""StsRsnInf"": {
+            ""Orgtr"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP04"" } } }
+            },
+            ""OrgnlTxRef"": {
+            ""PmtTpInf"": {
+            ""SvcLvl"": { ""Cd"": ""SRTP"" },
+            ""LclInstrm"": { ""Prtry"": ""NOTPROVIDED"" }
+            },
+            ""RmtInf"": { ""Ustrd"": ""Payment for invoice 12345."" },
+            ""Cdtr"": {
+            ""Id"": { ""OrgId"": { ""Othr"": { ""Id"": ""TRX-ID-112233"", ""SchmeNm"": { ""Cd"": ""BOID"" } } } },
+            ""Nm"": ""Azienda Creditrice S.p.A.""
+            },
+            ""DbtrAgt"": { ""FinInstnId"": { ""BICFI"": ""MOCKSP04"" } },
+            ""CdtrAgt"": { ""FinInstnId"": { ""BICFI"": ""MOCKSP04"" } },
+            ""CdtrAcct"": { ""Id"": { ""IBAN"": ""IT12L0123456789012345678901"" } },
+            ""Amt"": { ""InstdAmt"": 450.75 },
+            ""ReqdExctnDt"": { ""Dt"": ""2026-02-20Z"" },
+            ""XpryDt"": { ""Dt"": ""2026-03-10Z"" } }] } } ] } },
+            ""_links"": {
+            ""initialSepaRequestToPayUri"": {
+            ""href"": ""https://api-rtp-cb.cstar.pagopa.it/rtp/cb/requests/123"",
+            ""templated"": false } } }";
+            }</set-body>
+        </return-response>
+      </when>
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;LSSUDV05L25B272V&quot;))">
+        <return-response>
+          <set-status code="400" reason="Bad Request" />
+          <set-header name="Content-Type" exists-action="override">
+            <value>application/json</value>
+          </set-header>
+          <set-body>@{
+            return @"{
+            ""resourceId"": ""TestRtpMessageREJ1234567890XYZ"",
+            ""Document"": {
+            ""CdtrPmtActvtnReqStsRpt"": {
+            ""GrpHdr"": {
+            ""MsgId"": ""990e8400-e29b-41d4-a716-446655449999"",
+            ""CreDtTm"": ""2026-02-11T14:05:00Z"",
+            ""InitgPty"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP04"" } } }
+            },
+            ""OrgnlGrpInfAndSts"": {
+            ""OrgnlMsgId"": ""TestRtpMessageREJ-ORIG-ID"",
+            ""OrgnlMsgNmId"": ""pain.013.001.07"",
+            ""OrgnlCreDtTm"": ""2026-02-12T10:00:00Z""
+            },
+            ""OrgnlPmtInfAndSts"": [
+            {
+            ""OrgnlPmtInfId"": ""a1b2c3d4-e5f6-4789-8901-23456789abcd"",
+            ""TxInfAndSts"": {
+            ""StsId"": ""990e8400-e29b-41d4-a716-446655449999"",
+            ""OrgnlInstrId"": ""TestRtpMessageINSTR-REJECTED"",
+            ""OrgnlEndToEndId"": ""987654321098765432"",
+            ""TxSts"": ""RJCT"",
+            ""StsRsnInf"": {
+            ""Orgtr"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP04"" } } }
+            },
+            ""OrgnlTxRef"": {
+            ""PmtTpInf"": {
+            ""SvcLvl"": { ""Cd"": ""SRTP"" },
+            ""LclInstrm"": { ""Prtry"": ""NOTPROVIDED"" }
+            },
+            ""RmtInf"": { ""Ustrd"": ""Rifiuto tecnico transazione."" },
+            ""Cdtr"": {
+            ""Id"": { ""OrgId"": { ""Othr"": { ""Id"": ""TRX-REJ-999"", ""SchmeNm"": { ""Cd"": ""BOID"" } } } },
+            ""Nm"": ""Azienda Creditrice S.p.A.""
+            },
+            ""Dbtr"": {
+            ""Id"": { ""PrvtId"": { ""Othr"": { ""Id"": ""TRX-REJ-999"", ""SchmeNm"": { ""Cd"": ""POID"" } } } }
+            },
+            ""DbtrAgt"": { ""FinInstnId"": { ""BICFI"": ""MOCKSP04"" } },
+            ""CdtrAgt"": { ""FinInstnId"": { ""BICFI"": ""MOCKSP04"" } },
+            ""CdtrAcct"": { ""Id"": { ""IBAN"": ""IT00X0123456789012345678901"" } },
+            ""Amt"": { ""InstdAmt"": 120.0 },
+            ""ReqdExctnDt"": { ""Dt"": ""2026-02-15Z"" },
+            ""XpryDt"": { ""Dt"": ""2026-03-01Z"" } } } } ] } },
+            ""_links"": {
+            ""initialSepaRequestToPayUri"": {
+            ""href"": ""https://api-rtp-cb.cstar.pagopa.it/rtp/cb/requests/123"",
+            ""templated"": false } } }";
+            }</set-body>
+        </return-response>
+      </when>
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;RSSMRA85T10X000D&quot;))">
+        <return-response>
+          <set-status code="502" reason="Bad Gateway"/>
+          <set-header name="Content-Type" exists-action="override">
+            <value>application/json</value>
+          </set-header>
+        </return-response>
+      </when>
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;RSSMRA80A01H501W&quot;))">
+        <return-response>
+          <set-status code="201" reason="Created" />
+          <set-header name="Content-Type" exists-action="override">
+            <value>application/json</value>
+          </set-header>
+          <set-body template="none">"success"</set-body>
+        </return-response>
+      </when>
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;NLTJEU11T67X000L&quot;))">
+        <return-response>
+          <set-status code="201" reason="Created" />
+          <set-header name="Content-Type" exists-action="override">
+            <value>application/json</value>
+          </set-header>
+          <set-body template="none">"6180e0d9-4d6d-4617-9dc6-a6c786395617 processed correctly"</set-body>
+        </return-response>
+      </when>
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;QPRLKI34W21X000N&quot;))">
+        <return-response>
+          <set-status code="201" reason="Created" />
+          <set-header name="Content-Type" exists-action="override">
+            <value>application/json</value>
+          </set-header>
+          <set-body>InvalidResponse</set-body>
+        </return-response>
+      </when>
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;RPRLKI34W21X000N&quot;))">
+        <return-response>
+          <set-status code="400" reason="Bad request" />
+          <set-header name="Content-Type" exists-action="override">
+            <value>application/json</value>
+          </set-header>
+          <set-body template="none">{"InvalidResponse"</set-body>
+        </return-response>
+      </when>
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;SPRLKI34W21X000N&quot;))">
+        <return-response>
+          <set-status code="201" reason="Created" />
+          <set-header name="Content-Type" exists-action="override">
+            <value>application/json</value>
+          </set-header>
+          <set-body template="none">{"InvalidResponse"</set-body>
+        </return-response>
+      </when>
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;BNCLCU85M15F205W&quot;))">
+        <return-response>
+          <set-status code="201" reason="Created" />
+          <set-header name="Content-Type" exists-action="override">
+            <value>application/json</value>
+          </set-header>
+          <set-body>@{
+            return @"{
+            ""resourceId"": ""TestRtpMessageA1B2C3D4E5F6G7H8"",
+            ""Document"": {
+            ""CdtrPmtActvtnReqStsRpt"": {
+            ""GrpHdr"": {
+            ""MsgId"": ""550e8400-e29b-41d4-a716-446655440000"",
+            ""CreDtTm"": ""2026-02-11T14:00:00Z"",
+            ""InitgPty"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP04"" } } }
+            },
+            ""OrgnlGrpInfAndSts"": {
+            ""OrgnlMsgId"": ""TestRtpMessageKJ9283KSL01928374650"",
+            ""OrgnlMsgNmId"": ""pain.013.001.07"",
+            ""OrgnlCreDtTm"": ""2026-02-12T09:30:00Z""
+            },
+            ""OrgnlPmtInfAndSts"": [
+            {
+            ""OrgnlPmtInfId"": ""f47ac10b-58cc-4372-a567-0e02b2c3d479"",
+            ""TxInfAndSts"": [{
+            ""StsId"": ""550e8400-e29b-41d4-a716-446655440000"",
+            ""OrgnlInstrId"": ""TestRtpMessagePL098765432109876543"",
+            ""OrgnlEndToEndId"": ""123456789012345678"",
+            ""TxSts"": ""ACTC"",
+            ""StsRsnInf"": {
+            ""Orgtr"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP04"" } } }
+            },
+            ""OrgnlTxRef"": {
+            ""PmtTpInf"": {
+            ""SvcLvl"": { ""Cd"": ""SRTP"" },
+            ""LclInstrm"": { ""Prtry"": ""NOTPROVIDED"" }
+            },
+            ""RmtInf"": { ""Ustrd"": ""Payment for invoice 12345."" },
+            ""Cdtr"": {
+            ""Id"": { ""OrgId"": { ""Othr"": { ""Id"": ""TRX-ID-112233"", ""SchmeNm"": { ""Cd"": ""BOID"" } } } },
+            ""Nm"": ""Azienda Creditrice S.p.A.""
+            },
+            ""DbtrAgt"": { ""FinInstnId"": { ""BICFI"": ""MOCKSP04"" } },
+            ""CdtrAgt"": { ""FinInstnId"": { ""BICFI"": ""MOCKSP04"" } },
+            ""CdtrAcct"": { ""Id"": { ""IBAN"": ""IT12L0123456789012345678901"" } },
+            ""Amt"": { ""InstdAmt"": 450.75 },
+            ""ReqdExctnDt"": { ""Dt"": ""2026-02-20Z"" },
+            ""XpryDt"": { ""Dt"": ""2026-03-10Z"" } }] } } ] } },
+            ""_links"": {
+            ""initialSepaRequestToPayUri"": {
+            ""href"": ""https://api-rtp-cb.cstar.pagopa.it/rtp/cb/requests/123"",
+            ""templated"": false } } }";
+            }</set-body>
+        </return-response>
+      </when>
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;RSSGNN92P20H501Z&quot;))">
+        <return-response>
+          <set-status code="201" reason="Created" />
+          <set-header name="Content-Type" exists-action="override">
+            <value>application/json</value>
+          </set-header>
+          <set-body>@{
+            return @"{
+            ""resourceId"": ""TestRtpMessageA1B2C3D4E5F6G7H8"",
+            ""Document"": {
+            ""CdtrPmtActvtnReqStsRpt"": {
+            ""GrpHdr"": {
+            ""MsgId"": ""550e8400-e29b-41d4-a716-446655440000"",
+            ""CreDtTm"": ""2026-02-11T14:00:00Z"",
+            ""InitgPty"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP04"" } } }
+            },
+            ""OrgnlGrpInfAndSts"": {
+            ""OrgnlMsgId"": ""TestRtpMessageKJ9283KSL01928374650"",
+            ""OrgnlMsgNmId"": ""pain.013.001.07"",
+            ""OrgnlCreDtTm"": ""2026-02-12T09:30:00Z""
+            },
+            ""OrgnlPmtInfAndSts"": [
+            {
+            ""OrgnlPmtInfId"": ""f47ac10b-58cc-4372-a567-0e02b2c3d479"",
+            ""TxInfAndSts"": [{
+            ""StsId"": ""550e8400-e29b-41d4-a716-446655440000"",
+            ""OrgnlInstrId"": ""TestRtpMessagePL098765432109876543"",
+            ""OrgnlEndToEndId"": ""123456789012345678"",
+            ""TxSts"": ""ACTC"",
+            ""StsRsnInf"": {
+            ""Orgtr"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP04"" } } }
+            },
+            ""OrgnlTxRef"": {
+            ""PmtTpInf"": {
+            ""SvcLvl"": { ""Cd"": ""SRTP"" },
+            ""LclInstrm"": { ""Prtry"": ""NOTPROVIDED"" }
+            },
+            ""RmtInf"": { ""Ustrd"": ""Payment for invoice 12345."" },
+            ""Cdtr"": {
+            ""Id"": { ""OrgId"": { ""Othr"": { ""Id"": ""TRX-ID-112233"", ""SchmeNm"": { ""Cd"": ""BOID"" } } } },
+            ""Nm"": ""Azienda Creditrice S.p.A.""
+            },
+            ""DbtrAgt"": { ""FinInstnId"": { ""BICFI"": ""MOCKSP04"" } },
+            ""CdtrAgt"": { ""FinInstnId"": { ""BICFI"": ""MOCKSP04"" } },
+            ""CdtrAcct"": { ""Id"": { ""IBAN"": ""IT12L0123456789012345678901"" } },
+            ""Amt"": { ""InstdAmt"": 450.75 },
+            ""ReqdExctnDt"": { ""Dt"": ""2026-02-20Z"" },
+            ""XpryDt"": { ""Dt"": ""2026-03-10Z"" } }] } } ] } },
+            ""_links"": {
+            ""initialSepaRequestToPayUri"": {
+            ""href"": ""https://api-rtp-cb.cstar.pagopa.it/rtp/cb/requests/123"",
+            ""templated"": false } },
+            ""invalidField"": ""test"" }";
+            }</set-body>
+        </return-response>
+      </when>
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;DWQJHC32M47H159O&quot;))">
+        <return-response>
+          <set-status code="400" reason="Bad Request" />
+          <set-header name="Content-Type" exists-action="override">
+            <value>application/json</value>
+          </set-header>
+          <set-body>@{
+            return @"{
+            ""resourceId"": ""TestRtpMessageREJ1234567890XYZ"",
+            ""Document"": {
+            ""CdtrPmtActvtnReqStsRpt"": {
+            ""GrpHdr"": {
+            ""MsgId"": ""990e8400-e29b-41d4-a716-446655449999"",
+            ""CreDtTm"": ""2026-02-11T14:05:00Z"",
+            ""InitgPty"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP04"" } } }
+            },
+            ""OrgnlGrpInfAndSts"": {
+            ""OrgnlMsgId"": ""TestRtpMessageREJ-ORIG-ID"",
+            ""OrgnlMsgNmId"": ""pain.013.001.07"",
+            ""OrgnlCreDtTm"": ""2026-02-12T10:00:00Z""
+            },
+            ""OrgnlPmtInfAndSts"": [
+            {
+            ""OrgnlPmtInfId"": ""a1b2c3d4-e5f6-4789-8901-23456789abcd"",
+            ""TxInfAndSts"": {
+            ""StsId"": ""990e8400-e29b-41d4-a716-446655449999"",
+            ""OrgnlInstrId"": ""TestRtpMessageINSTR-REJECTED"",
+            ""OrgnlEndToEndId"": ""987654321098765432"",
+            ""TxSts"": ""RJCT"",
+            ""StsRsnInf"": {
+            ""Orgtr"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP04"" } } }
+            },
+            ""OrgnlTxRef"": {
+            ""PmtTpInf"": {
+            ""SvcLvl"": { ""Cd"": ""SRTP"" },
+            ""LclInstrm"": { ""Prtry"": ""NOTPROVIDED"" }
+            },
+            ""RmtInf"": { ""Ustrd"": ""Rifiuto tecnico transazione."" },
+            ""Cdtr"": {
+            ""Id"": { ""OrgId"": { ""Othr"": { ""Id"": ""TRX-REJ-999"", ""SchmeNm"": { ""Cd"": ""BOID"" } } } },
+            ""Nm"": ""Azienda Creditrice S.p.A.""
+            },
+            ""Dbtr"": {
+            ""Id"": { ""PrvtId"": { ""Othr"": { ""Id"": ""TRX-REJ-999"", ""SchmeNm"": { ""Cd"": ""POID"" } } } }
+            },
+            ""DbtrAgt"": { ""FinInstnId"": { ""BICFI"": ""MOCKSP04"" } },
+            ""CdtrAgt"": { ""FinInstnId"": { ""BICFI"": ""MOCKSP04"" } },
+            ""CdtrAcct"": { ""Id"": { ""IBAN"": ""IT00X0123456789012345678901"" } },
+            ""Amt"": { ""InstdAmt"": 120.0 },
+            ""ReqdExctnDt"": { ""Dt"": ""2026-02-15Z"" },
+            ""XpryDt"": { ""Dt"": ""2026-03-01Z"" } } } } ] } },
+            ""_links"": {
+            ""initialSepaRequestToPayUri"": {
+            ""href"": ""https://api-rtp-cb.cstar.pagopa.it/rtp/cb/requests/123"",
+            ""templated"": false } },
+            ""invalidField"": ""test"" }";
+            }</set-body>
+        </return-response>
+      </when>
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;NDRSCC78T31H304R&quot;))">
+        <return-response>
+          <set-status code="400" reason="Bad Request" />
+          <set-header name="Content-Type" exists-action="override">
+            <value>application/json</value>
+          </set-header>
+          <set-body>@{
+            return @"{
+            ""resourceId"": ""TestRtpMessageREJ1234567890XYZ"",
+            ""Document"": {
+            ""CdtrPmtActvtnReqStsRpt"": {
+            ""GrpHdr"": {
+            ""MsgId"": ""990e8400-e29b-41d4-a716-446655449999"",
+            ""CreDtTm"": ""2026-02-11T14:05:00Z"",
+            ""InitgPty"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP04"" } } }
+            },
+            ""OrgnlGrpInfAndSts"": {
+            ""OrgnlMsgId"": ""TestRtpMessageREJ-ORIG-ID"",
+            ""OrgnlMsgNmId"": ""pain.013.001.07"",
+            ""OrgnlCreDtTm"": ""2026-02-12T10:00:00Z""
+            },
+            ""OrgnlPmtInfAndSts"": [
+            {
+            ""OrgnlPmtInfId"": ""a1b2c3d4-e5f6-4789-8901-23456789abcd"",
+            ""TxInfAndSts"": {
+            ""StsId"": ""990e8400-e29b-41d4-a716-446655449999"",
+            ""OrgnlInstrId"": ""TestRtpMessageINSTR-REJECTED"",
+            ""OrgnlEndToEndId"": ""987654321098765432"",
+            ""TxSts"": ""RJCT"",
+            ""StsRsnInf"": {
+            ""Orgtr"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP04"" } } }
+            },
+            ""OrgnlTxRef"": {
+            ""PmtTpInf"": {
+            ""SvcLvl"": { ""Cd"": ""SRTP"" },
+            ""LclInstrm"": { ""Prtry"": ""NOTPROVIDED"" }
+            },
+            ""RmtInf"": { ""Ustrd"": ""Rifiuto tecnico transazione."" },
+            ""Cdtr"": {
+            ""Id"": { ""OrgId"": { ""Othr"": { ""Id"": ""TRX-REJ-999"", ""SchmeNm"": { ""Cd"": ""BOID"" } } } },
+            ""Nm"": ""Azienda Creditrice S.p.A.""
+            },
+            ""Dbtr"": {
+            ""Id"": { ""PrvtId"": { ""Othr"": { ""Id"": ""TRX-REJ-999"", ""SchmeNm"": { ""Cd"": ""POID"" } } } }
+            },
+            ""DbtrAgt"": { ""FinInstnId"": { ""BICFI"": ""MOCKSP04"" } },
+            ""CdtrAgt"": { ""FinInstnId"": { ""BICFI"": ""MOCKSP04"" } },
+            ""CdtrAcct"": { ""Id"": { ""IBAN"": ""IT00X0123456789012345678901"" } },
+            ""Amt"": { ""InstdAmt"": 120.0 },
+            ""ReqdExctnDt"": { ""Dt"": ""2026-02-15Z"" },
+            ""XpryDt"": { ""Dt"": ""2026-03-01Z"" } } } } ] } },
+            ""_links"": {
+            ""initialSepaRequestToPayUri"": {
+            ""href"": ""https://api-rtp-cb.cstar.pagopa.it/rtp/cb/requests/123"",
+            ""templated"": false } } }";
+            }</set-body>
+        </return-response>
+      </when>
+      <otherwise>
+        <return-response>
+          <set-status code="201" reason="Created" />
+          <set-header name="Content-Type" exists-action="override">
+            <value>application/json</value>
+          </set-header>
+          <set-body>@("{}")</set-body>
+        </return-response>
+      </otherwise>
+    </choose>
+  </inbound>
+  <backend>
+    <base />
+  </backend>
+  <outbound>
+    <base />
+  </outbound>
+  <on-error>
+    <base />
+  </on-error>
+</policies>

--- a/src/srtp/api/test/mock_policy_epc_v4.xml
+++ b/src/srtp/api/test/mock_policy_epc_v4.xml
@@ -76,7 +76,7 @@
             ""OrgnlGrpInfAndSts"": {
             ""OrgnlMsgId"": ""TestRtpMessageREJ-ORIG-ID"",
             ""OrgnlMsgNmId"": ""pain.013.001.07"",
-            ""OrgnlCreDtTm"": ""2026-02-12T10:00:00Z""
+            ""OrgnlCreDtTm"": ""2026-02-12T10:00:00.000Z""
             },
             ""OrgnlPmtInfAndSts"": [
             {


### PR DESCRIPTION
### List of changes

- Added `EPC133-22 v1.0 SRTP API YAML V4.0.yaml` OpenAPI descriptor for EPC spec V4.0
- Extended `rtp-mock` with `version = "v1"` and a `version_set` (Header-based scheme, `Version` header) to make it the anchor of a version set
- Added `rtp-mock-v4` API entry (`version = "v2"`) referencing the same version set, importing the V4.0 spec
- Created `mock_policy_epc_v4.xml` with V4.0-compliant payloads (see schema changes below)
- Added `postRequestToPayRequests-v4` and `postRequestToPayCancellationRequest-v4` operation policies pointing at `rtp-mock-v4`
- Fixed Terraform `Inconsistent conditional result types` error: replaced `condition ? {} : { heterogeneous entries }` with `{ for k, v in { key = condition ? null : value } : k => v if v != null }` in both `apis` and `api_operation_policy` merges

### Motivation and context

This implementation provides a way to simulate a _Debtor Service Provider_ in the new _EPC SRTP v4.0_ flow like it's currently done for _v3.2_ standard.

Both versions co-exist under the same APIM path (`rtp/mock`), differentiated by the `Version` request header:

| Header value | Spec | API key |
|---|---|---|
| `v1` | EPC133-22 V3.2 | `rtp-mock` |
| `v2` | EPC133-22 V4.0 | `rtp-mock-v4` |

### Type of changes

- [x] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [x] DEV
- [x] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No
