### PR TITLE
fix: [SRTP-1986] update fiscalCode mocked

### DIFF
--- a/src/srtp/api/test/mock_policy_epc.xml
+++ b/src/srtp/api/test/mock_policy_epc.xml
@@ -57,7 +57,7 @@
             }</set-body>
         </return-response>
       </when>
-      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;LSSUDV05L25B272V&quot;))">
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;CJHKMM89B16L936J&quot;))">
         <return-response>
           <set-status code="400" reason="Bad Request" />
           <set-header name="Content-Type" exists-action="override">
@@ -115,7 +115,7 @@
             }</set-body>
         </return-response>
       </when>
-      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;RSSMRA85T10X000D&quot;))">
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;GXSHCN92D13E386R&quot;))">
         <return-response>
           <set-status code="502" reason="Bad Gateway"/>
           <set-header name="Content-Type" exists-action="override">
@@ -132,7 +132,7 @@
           <set-body>@("{ \"status\": \"success\", \"message\": \"Mock response for RSSMRA80A01H501W\" }")</set-body>
         </return-response>
       </when>
-      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;NLTJEU11T67X000L&quot;))">
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;PWUZMY64L16L746M&quot;))">
         <return-response>
           <set-status code="201" reason="Created" />
           <set-header name="Content-Type" exists-action="override">
@@ -141,7 +141,7 @@
           <set-body template="none">{"VoidResponse":"6180e0d9-4d6d-4617-9dc6-a6c786395617 processed correctly"}</set-body>
         </return-response>
       </when>
-      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;QPRLKI34W21X000N&quot;))">
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;KCUFWB22H17E127J&quot;))">
         <return-response>
           <set-status code="201" reason="Created" />
           <set-header name="Content-Type" exists-action="override">
@@ -150,7 +150,7 @@
           <set-body>InvalidResponse</set-body>
         </return-response>
       </when>
-      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;RPRLKI34W21X000N&quot;))">
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;KNUPNC21C25E872Z&quot;))">
         <return-response>
           <set-status code="400" reason="Bad request" />
           <set-header name="Content-Type" exists-action="override">
@@ -159,7 +159,7 @@
           <set-body template="none">{"InvalidResponse"</set-body>
         </return-response>
       </when>
-      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;SPRLKI34W21X000N&quot;))">
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;TJCCHE55L01J301L&quot;))">
         <return-response>
           <set-status code="201" reason="Created" />
           <set-header name="Content-Type" exists-action="override">

--- a/src/srtp/api/test/mock_policy_gpd.xml
+++ b/src/srtp/api/test/mock_policy_gpd.xml
@@ -14,7 +14,7 @@
     <inbound>
         <base />
         <choose>
-            <when condition="@(context.Request.Body.As<String>(preserveContent: true).Contains(&quot;GHIJKL34M56N789O&quot;))">
+            <when condition="@(context.Request.Body.As<String>(preserveContent: true).Contains(&quot;TYJLTY06A11D630J&quot;))">
                 <return-response>
                     <set-status code="400" reason="Bad Request" />
                     <set-header name="Content-Type" exists-action="override">
@@ -22,7 +22,7 @@
                     </set-header>
                 </return-response>
             </when>
-            <when condition="@(context.Request.Body.As<String>(preserveContent: true).Contains(&quot;PQRSTU56V78W901P&quot;))">
+            <when condition="@(context.Request.Body.As<String>(preserveContent: true).Contains(&quot;WPOLCQ72E14E278X&quot;))">
                 <return-response>
                     <set-status code="401" reason="Unauthorized" />
                     <set-header name="Content-Type" exists-action="override">
@@ -30,7 +30,7 @@
                     </set-header>
                 </return-response>
             </when>
-            <when condition="@(context.Request.Body.As<String>(preserveContent: true).Contains(&quot;XYZABC78D90E123Q&quot;))">
+            <when condition="@(context.Request.Body.As<String>(preserveContent: true).Contains(&quot;MSTHTZ25P19A540T&quot;))">
                 <return-response>
                     <set-status code="403" reason="Forbidden" />
                     <set-header name="Content-Type" exists-action="override">
@@ -38,7 +38,7 @@
                     </set-header>
                 </return-response>
             </when>
-            <when condition="@(context.Request.Body.As<String>(preserveContent: true).Contains(&quot;DEFXYZ90F12G345R&quot;))">
+            <when condition="@(context.Request.Body.As<String>(preserveContent: true).Contains(&quot;WMCPSJ17L23L318D&quot;))">
                 <return-response>
                     <set-status code="406" reason="Not Acceptable" />
                     <set-header name="Content-Type" exists-action="override">
@@ -46,7 +46,7 @@
                     </set-header>
                 </return-response>
             </when>
-            <when condition="@(context.Request.Body.As<String>(preserveContent: true).Contains(&quot;HIJKLM12H34I567S&quot;))">
+            <when condition="@(context.Request.Body.As<String>(preserveContent: true).Contains(&quot;TVTDBY87A24I163F&quot;))">
                 <return-response>
                     <set-status code="409" reason="Conflict" />
                     <set-header name="Content-Type" exists-action="override">
@@ -54,7 +54,7 @@
                     </set-header>
                 </return-response>
             </when>
-            <when condition="@(context.Request.Body.As<String>(preserveContent: true).Contains(&quot;KLMNOP34J56K789T&quot;))">
+            <when condition="@(context.Request.Body.As<String>(preserveContent: true).Contains(&quot;CDDXWE97E08K703Y&quot;))">
                 <return-response>
                     <set-status code="415" reason="Unsupported Media Type" />
                     <set-header name="Content-Type" exists-action="override">
@@ -62,7 +62,7 @@
                     </set-header>
                 </return-response>
             </when>
-            <when condition="@(context.Request.Body.As<String>(preserveContent: true).Contains(&quot;OPQRST56L78M901U&quot;))">
+            <when condition="@(context.Request.Body.As<String>(preserveContent: true).Contains(&quot;DRBHYD07M13E835B&quot;))">
                 <return-response>
                     <set-status code="429" reason="Too Many Requests" />
                     <set-header name="Content-Type" exists-action="override">

--- a/src/srtp/api/test/mock_policy_takeover.xml
+++ b/src/srtp/api/test/mock_policy_takeover.xml
@@ -14,7 +14,7 @@
   <inbound>
     <base/>
     <choose>
-      <when condition="@(context.Request.Body.As<String>(preserveContent: true).Contains(&quot;RSSMRA85T10X000D&quot;))">
+      <when condition="@(context.Request.Body.As<String>(preserveContent: true).Contains(&quot;WDMVJN16A10K954W&quot;))">
         <return-response>
           <set-status code="502" reason="Bad Gateway"/>
           <set-header name="Content-Type" exists-action="override">


### PR DESCRIPTION
### List of changes

Replaced invalid fiscal codes in the APIM mock policies for EPC, GPD, and Takeover with valid ones that pass the updated `fiscalCode` regex.

### Motivation and context

Several fiscal codes used in the APIM mock policies were synthetic/placeholder codes that no longer satisfied the new regex, causing mock matching to fail at runtime. This PR replaces them with valid fiscal codes that conform to the updated pattern.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [x] DEV
- [x] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->