### PR TITLE
feat: [SRTP-1989] Add GET Payer Status API

### DIFF
--- a/src/srtp/api/pagopa/activation.yaml
+++ b/src/srtp/api/pagopa/activation.yaml
@@ -406,7 +406,7 @@ paths:
           #description: Unexpected error
           $ref: '#/components/responses/Error'
 
-  /activations/payer/status:
+  /activations/payer/{payerId}/status:
     get:
       operationId: getPayerStatus
       summary: Returns the activation status of a Payer.
@@ -422,7 +422,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/RequestId'
         - $ref: '#/components/parameters/Version'
-        - $ref: '#/components/parameters/PayerId'
+        - $ref: '#/components/parameters/PayerIdPath'
       responses:
         "200":
           $ref: '#/components/responses/PayerStatus'
@@ -1066,6 +1066,14 @@ components:
       required: true
       schema:
         $ref: '#/components/schemas/PageSize'
+
+    PayerIdPath:
+      name: payerId
+      in: path
+      description: Identifier of the Payer.
+      required: true
+      schema:
+        $ref: '#/components/schemas/FiscalCode'
 
     PayerId:
       name: PayerId

--- a/src/srtp/api/pagopa/activation.yaml
+++ b/src/srtp/api/pagopa/activation.yaml
@@ -406,6 +406,56 @@ paths:
           #description: Unexpected error
           $ref: '#/components/responses/Error'
 
+  /activations/payer/status:
+    get:
+      operationId: getPayerStatus
+      summary: Returns the activation status of a Payer.
+      description: |
+        Returns whether a given Payer is active in the RTP system.
+
+        When the operation is used by a non-admin subject, the system returns
+        the status only for activations whose `serviceProviderDebtor` matches the `sub`
+        claim of the access token.
+      tags: [read]
+      security:
+        - oAuth2: [read_rtp_all, read_rtp_activations]
+      parameters:
+        - $ref: '#/components/parameters/RequestId'
+        - $ref: '#/components/parameters/Version'
+        - $ref: '#/components/parameters/PayerId'
+      responses:
+        "200":
+          $ref: '#/components/responses/PayerStatus'
+        "400":
+          #  Possible error codes:
+          #  - 01021008E: Missing Payer ID
+          #  - 01021013E: Invalid Payer ID format
+          $ref: '#/components/responses/BadRequestError'
+        "401":
+          #  Possible error codes:
+          #  - 01011000E: Missing authentication token
+          #  - 01011001E: Invalid token format
+          #  - 01011002E: Expired token
+          #  - 01011003F: Invalid signature
+          $ref: '#/components/responses/UnauthorizedError'
+        "403":
+          #  Possible error codes:
+          #  - 01011004E: Insufficient permissions
+          #  - 01011005E: Invalid scope
+          $ref: '#/components/responses/ForbiddenError'
+        "429":
+          #  Possible error codes:
+          #  - 01051000E: Rate limit exceeded
+          #  - 01051001E: Quota exceeded
+          $ref: '#/components/responses/TooManyRequestsError'
+        "500":
+          #  Possible error codes:
+          #  - 01091000F: Internal server error
+          #  - 01091001F: Database error
+          $ref: '#/components/responses/InternalServerError'
+        default:
+          $ref: '#/components/responses/Error'
+
   /activations/payer:
     get:
       operationId: findActivationByPayerId

--- a/src/srtp/api/pagopa/activation.yaml
+++ b/src/srtp/api/pagopa/activation.yaml
@@ -414,7 +414,7 @@ paths:
         Returns whether a given Payer is active in the RTP system.
 
         When the operation is used by a non-admin subject, the system returns
-        the status only for activations whose `serviceProviderDebtor` matches the `sub`
+        the status only for activations whose Payer RTP Service Provider ID matches the `sub`
         claim of the access token.
       tags: [read]
       security:

--- a/src/srtp/api/pagopa/activation.yaml
+++ b/src/srtp/api/pagopa/activation.yaml
@@ -418,7 +418,7 @@ paths:
         claim of the access token.
       tags: [read]
       security:
-        - oAuth2: [read_rtp_all, read_rtp_activations]
+        - oAuth2: [admin_rtp_activations, read_rtp_activations, read_rtp_all]
       parameters:
         - $ref: '#/components/parameters/RequestId'
         - $ref: '#/components/parameters/Version'

--- a/src/srtp/api/pagopa/activation.yaml
+++ b/src/srtp/api/pagopa/activation.yaml
@@ -1272,6 +1272,20 @@ components:
         RateLimit-Reset:
           $ref: '#/components/headers/RateLimitReset'
 
+    PayerStatus:
+      description: Response with the activation status of a Payer.
+      headers:
+        Access-Control-Allow-Origin:
+          $ref: '#/components/headers/AccessControlAllowOrigin'
+        RateLimit-Limit:
+          $ref: '#/components/headers/RateLimitLimit'
+        RateLimit-Reset:
+          $ref: '#/components/headers/RateLimitReset'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/PayerStatus'
+
     PageOfActivations:
       description: Response to the request to get RTP activations.
       headers:

--- a/src/srtp/api/pagopa/activation.yaml
+++ b/src/srtp/api/pagopa/activation.yaml
@@ -903,6 +903,21 @@ components:
           nextActivationId: "d0d654e6-97da-4848-b568-99fedccb642b"
           size: 1
 
+    PayerStatus:
+      description: Activation status of a Payer.
+      type: object
+      additionalProperties: false
+      properties:
+        isActive:
+          type: boolean
+          description: >
+            True if the Payer has an active RTP activation visible to the caller.
+            False if no activation exists or the caller is not authorized to see it.
+      required:
+        - isActive
+      example:
+        isActive: true
+
     PartyId:
       description: |
         Unique and unambiguous identification of a party.


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

  - New `GET /activations/payer/{payerId}/status` endpoint in `activation.yaml`
  - New `PayerStatus` schema (`{ isActive: boolean }`)
  - New `PayerIdPath` path parameter component
  - New `PayerStatus` response component

  ### Motivation and context

  _Debtor Service Providers_ need to check whether a citizen (payer) is active in the _RTP_ system without retrieving full activation data. The endpoint returns `{ "isActive": true/false }` — non-admin callers
  only see `true` for activations matching their JWT `sub` claim; all other cases (not found or unauthorized) return `false` to prevent information disclosure.

  ### Type of changes

  - [x] Add new resources
  - [ ] Update configuration to existing resources
  - [ ] Remove existing resources

  ### Env to apply
  
  - [x] DEV
  - [x] UAT
  - [x] PROD

  ### Does this introduce a change to production resources with possible user impact?

  - [ ] Yes, users may be impacted applying this change
  - [x] No

  ### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

  - [ ] Yes
  - [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
