### PR TITLE
feat: [SRTP-1989] Switch mock APIs to path-based versioning

### DIFF
--- a/src/srtp/99_locals.tf
+++ b/src/srtp/99_locals.tf
@@ -287,14 +287,13 @@ locals {
       }
     }
     },
-    { for k, v in {
-      # RTP Mock v1 (EPC v3.1)
-      rtp-mock = var.env_short == "p" ? null : {
+      var.env_short == "p" ? {} : {
+      # RTP Mock v1 (EPC V3.1)
+      rtp-mock = {
         description           = "RTP ITN MOCK API EPC V3.1"
         display_name          = "RTP ITN MOCK API EPC V3.1"
-        path                  = "${local.api_context_path}/mock"
+        path                  = "${local.api_context_path}/mock/v1"
         revision              = "1"
-        version               = "v1"
         protocols             = ["https"]
         subscription_required = false
         product               = "srtp"
@@ -302,25 +301,17 @@ locals {
           content_format = "openapi"
           content_value  = templatefile("./api/epc/EPC133-22_v3.1_SRTP_spec.openapi.yaml", {})
         }
-        version_set = {
-          name                = "${var.env_short}-rtp-mock-epc"
-          display_name        = "RTP ITN MOCK API EPC"
-          versioning_scheme   = "Header"
-          version_header_name = "Version"
-        }
       }
 
       # RTP Mock v2 (EPC V4.0)
-      rtp-mock-v4 = var.env_short == "p" ? null : {
+      rtp-mock-v4 = {
         description           = "RTP ITN MOCK API EPC V4.0"
         display_name          = "RTP ITN MOCK API EPC V4.0"
-        path                  = "${local.api_context_path}/mock"
+        path                  = "${local.api_context_path}/mock/v2"
         revision              = "1"
-        version               = "v2"
         protocols             = ["https"]
         subscription_required = false
         product               = "srtp"
-        version_set_ref       = "rtp-mock"
         import_descriptor = {
           content_format = "openapi"
           content_value  = templatefile("./api/epc/EPC133-22 v1.0 SRTP API YAML V4.0.yaml", {})
@@ -328,7 +319,7 @@ locals {
       }
 
       # RTP GPD Message Processing Mock
-      rtp-gpd-message-mock = var.env_short == "p" ? null : {
+      rtp-gpd-message-mock = {
         description           = "RTP ITN GPD Message Mock API"
         display_name          = "RTP ITN GPD Message Mock API"
         path                  = "${local.api_context_path}/mock/gpd"
@@ -343,7 +334,7 @@ locals {
       }
 
       # RTP Takeover Mock
-      rtp-takeover-mock = var.env_short == "p" ? null : {
+      rtp-takeover-mock = {
         description           = "RTP ITN MOCK API TAKEOVER"
         display_name          = "RTP ITN MOCK API TAKEOVER"
         path                  = "${local.api_context_path}/mock/takeover"
@@ -356,7 +347,7 @@ locals {
           content_value  = templatefile("./api/pagopa/takeover.yaml", {})
         }
       }
-    } : k => v if v != null }
+    }
   )
   products = {
     # SRTP

--- a/src/srtp/99_locals.tf
+++ b/src/srtp/99_locals.tf
@@ -292,8 +292,9 @@ locals {
       rtp-mock = {
         description           = "RTP ITN MOCK API EPC V3.1"
         display_name          = "RTP ITN MOCK API EPC V3.1"
-        path                  = "${local.api_context_path}/mock/v1"
+        path                  = "${local.api_context_path}/mock"
         revision              = "1"
+        version               = "v1"
         protocols             = ["https"]
         subscription_required = false
         product               = "srtp"
@@ -301,14 +302,21 @@ locals {
           content_format = "openapi"
           content_value  = templatefile("./api/epc/EPC133-22_v3.1_SRTP_spec.openapi.yaml", {})
         }
+        version_set = {
+          name              = "${var.env_short}-rtp-mock-epc"
+          display_name      = "RTP ITN MOCK API EPC"
+          versioning_scheme = "Segment"
+        }
       }
 
       # RTP Mock v2 (EPC V4.0)
       rtp-mock-v4 = {
         description           = "RTP ITN MOCK API EPC V4.0"
         display_name          = "RTP ITN MOCK API EPC V4.0"
-        path                  = "${local.api_context_path}/mock/v2"
+        path                  = "${local.api_context_path}/mock"
         revision              = "1"
+        version               = "v2"
+        version_set_ref       = "rtp-mock"
         protocols             = ["https"]
         subscription_required = false
         product               = "srtp"

--- a/src/srtp/99_locals.tf
+++ b/src/srtp/99_locals.tf
@@ -287,9 +287,9 @@ locals {
       }
     }
     },
-      var.env_short == "p" ? {} : {
+    { for k, v in {
       # RTP Mock v1 (EPC V3.1)
-      rtp-mock = {
+      rtp-mock = var.env_short == "p" ? null : {
         description           = "RTP ITN MOCK API EPC V3.1"
         display_name          = "RTP ITN MOCK API EPC V3.1"
         path                  = "${local.api_context_path}/mock"
@@ -310,7 +310,7 @@ locals {
       }
 
       # RTP Mock v2 (EPC V4.0)
-      rtp-mock-v4 = {
+      rtp-mock-v4 = var.env_short == "p" ? null : {
         description           = "RTP ITN MOCK API EPC V4.0"
         display_name          = "RTP ITN MOCK API EPC V4.0"
         path                  = "${local.api_context_path}/mock"
@@ -327,7 +327,7 @@ locals {
       }
 
       # RTP GPD Message Processing Mock
-      rtp-gpd-message-mock = {
+      rtp-gpd-message-mock = var.env_short == "p" ? null : {
         description           = "RTP ITN GPD Message Mock API"
         display_name          = "RTP ITN GPD Message Mock API"
         path                  = "${local.api_context_path}/mock/gpd"
@@ -342,7 +342,7 @@ locals {
       }
 
       # RTP Takeover Mock
-      rtp-takeover-mock = {
+      rtp-takeover-mock = var.env_short == "p" ? null : {
         description           = "RTP ITN MOCK API TAKEOVER"
         display_name          = "RTP ITN MOCK API TAKEOVER"
         path                  = "${local.api_context_path}/mock/takeover"
@@ -355,7 +355,7 @@ locals {
           content_value  = templatefile("./api/pagopa/takeover.yaml", {})
         }
       }
-    }
+    } : k => v if v != null }
   )
   products = {
     # SRTP


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
  
  - Replaced APIM header-based versioning with path-based versioning for mock APIs
  - `rtp-mock` (EPC v3.1): updated `version_set.versioning_scheme` from `Header` to `Segment`, removed `version_header_name`
  - `rtp-mock-v4` (EPC v4.0): added to version set via `version_set_ref`, path kept as base `mock` (APIM Segment versioning appends `/v1`, `/v2` automatically)

  ### Motivation and context

  Mock APIs were sharing a single APIM version set routed via `Version` header. However, EPC standard APIs do not declare a `Version` header — using it for versioning broke compliance. Switching to APIM Segment versioning removes the `Version` header requirement: APIM routes consumers to the correct standard
  version via URL path (`/mock/v1`, `/mock/v2`) while keeping a single version set in state.

  ### Type of changes

  - [ ] Add new resources
  - [x] Update configuration to existing resources
  - [ ] Remove existing resources

  ### Env to apply

  - [x] DEV
  - [x] UAT
  - [ ] PROD

  ### Does this introduce a change to production resources with possible user impact?

  - [ ] Yes, users may be impacted applying this change
  - [x] No

  ### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

  - [ ] Yes
  - [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
This implementation has been tested both in `dev` and `uat` environment by means of the _RTP WebForm_ and _Postman_ clients.

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
