### PR TITLE
feat: [SRTP-1987] Update swagger

### DIFF
--- a/src/srtp/api/pagopa/send.openapi.yaml
+++ b/src/srtp/api/pagopa/send.openapi.yaml
@@ -900,10 +900,10 @@ components:
           description: IUV identifier (15 to 17 digits)
         subject:
           type: string
-          maxLength: 140
+          maxLength: 118
         description:
           type: string
-          maxLength: 140
+          maxLength: 133
         ec_tax_code:
           type: string
           pattern: "^(\\d{11}|\\d{16})$"


### PR DESCRIPTION
### List of changes

Updated `maxLength` constraints for two fields in the `send.openapi.yaml` schema (`src/srtp/api/pagopa/send.openapi.yaml`):

- `subject`: `maxLength` reduced from `140` to `118`
- `description`: `maxLength` reduced from `140` to `133`

### Motivation and context

The Send API schema had `maxLength: 140` for both `subject` and `description` fields. Actual backend constraints are stricter — aligning the OpenAPI spec to the real limits prevents clients from sending payloads that would be rejected at runtime.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [x] DEV
- [x] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

Schema-only change, no infrastructure resources affected.

---

### If PR is partially applied, why? (reserved to mantainers)

N/A
