### PR TITLE
feat: [SRTP-1995] SRTP callback accept versionless header

### DIFF
--- a/src/srtp/99_locals.tf
+++ b/src/srtp/99_locals.tf
@@ -163,6 +163,23 @@ locals {
       }
     }
 
+    # RTP CALLBACK original — fallback for requests without Version header, routes to v1 backend
+    rtp-callback-original = {
+      description           = "RTP ITN CALLBACK API"
+      display_name          = "RTP ITN CALLBACK API"
+      path                  = "${local.api_context_path}/cb"
+      revision              = "1"
+      protocols             = ["https"]
+      service_url           = "${local.api_service_url}/rtpsender/"
+      subscription_required = false
+      product               = "srtp"
+      version_set_ref       = "rtp-callback"
+      import_descriptor = {
+        content_format = "openapi"
+        content_value  = templatefile("./api/epc/callback.openapi.yaml", {})
+      }
+    }
+
     # RTP CALLBACK v2
     rtp-callback-v2 = {
       description           = "RTP ITN CALLBACK API v2"


### PR DESCRIPTION
### List of changes

- Added `rtp-callback-original` API entry in `src/srtp/99_locals.tf` to handle RTP callback requests that do not include a `Version` header.

### Motivation and context

APIM uses header-based versioning (`Version` header) for the RTP callback API. When a request arrives without the `Version` header, APIM cannot match any versioned API and returns a `404 Not Found`. Some callback senders (e.g. EPC-compliant Service Providers) do not include the `Version` header in their requests.

To support these clients without breaking existing versioned routing, an "Original" API entry has been added to the existing `rtp-callback` version set. This entry acts as the fallback for unversioned requests and routes them to the v1 backend (`rtpsender/`).

The routing behaviour after this change is:

| `Version` header | Routed to |
|---|---|
| absent | `rtp-callback-original` → `rtpsender/` (v1 backend) |
| `v1` | `rtp-callback` → `rtpsender/` |
| `v2` | `rtp-callback-v2` → `rtpsenderv2/` |

No other APIs or version sets are affected by this change.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [x] DEV
- [x] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
