### PR TITLE
feat: [SRTP-1996] rollback RTP callback versioning and consolidate API definitions

### DIFF
--- a/src/srtp/99_locals.tf
+++ b/src/srtp/99_locals.tf
@@ -140,41 +140,16 @@ locals {
       }
     }
 
-    # RTP CALLBACK v1
+    # RTP CALLBACK
     rtp-callback = {
       description           = "RTP ITN CALLBACK API"
       display_name          = "RTP ITN CALLBACK API"
       path                  = "${local.api_context_path}/cb"
       revision              = "1"
-      version               = "v1"
       protocols             = ["https"]
       service_url           = "${local.api_service_url}/rtpsender/"
       subscription_required = false
       product               = "srtp"
-      import_descriptor = {
-        content_format = "openapi"
-        content_value  = templatefile("./api/epc/callback.openapi.yaml", {})
-      }
-      version_set = {
-        name                = "${var.env_short}-rtp-callback-v2"
-        display_name        = "RTP ITN CALLBACK API"
-        versioning_scheme   = "Header"
-        version_header_name = "Version"
-      }
-    }
-
-    # RTP CALLBACK v2
-    rtp-callback-v2 = {
-      description           = "RTP ITN CALLBACK API v2"
-      display_name          = "RTP ITN CALLBACK API"
-      path                  = "${local.api_context_path}/cb"
-      revision              = "1"
-      version               = "v2"
-      protocols             = ["https"]
-      service_url           = "${local.api_service_url}/rtpsenderv2/"
-      subscription_required = false
-      product               = "srtp"
-      version_set_ref       = "rtp-callback"
       import_descriptor = {
         content_format = "openapi"
         content_value  = templatefile("./api/epc/callback.openapi.yaml", {})


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

- Removed versioning configuration (`version = "v1"`) and the associated `version_set` from the `rtp-callback` API.
- Completely removed the `rtp-callback-v2` API definition block, cleaning up the unused/rolled-back v2 endpoints.

### Motivation and context

This pull request rolls back the versioning policy previously introduced for the RTP Sender Callback API. The goal is to restore the `rtp-callback` API to its original, non-versioned state by removing the API version sets and the v2 fragment that are no longer needed.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [x] Remove existing resources

### Env to apply

- [x] DEV
- [x] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

Note: Reverting an API from a versioned state to an unversioned state in Azure API Management via Terraform may require a targeted state removal and manual deletion of the existing API on the Azure Portal to avoid validation/conflict errors during the pipeline apply phase.

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
