### PR TITLE
fix: [SRTP-2000] fix EPC v4 policy mock

### DIFF
--- a/src/srtp/api/test/mock_policy_epc_v4.xml
+++ b/src/srtp/api/test/mock_policy_epc_v4.xml
@@ -32,7 +32,8 @@
             ""OrgnlEndToEndId"": ""123456789012345678"",
             ""TxSts"": ""ACTC"",
             ""StsRsnInf"": {
-            ""Orgtr"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP04"" } } }
+            ""Orgtr"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP04"" } } },
+            ""AddtlInf"": ""Redirect pending""
             },
             ""OrgnlTxRef"": {
             ""PmtTpInf"": {
@@ -49,7 +50,7 @@
             ""CdtrAcct"": { ""Id"": { ""IBAN"": ""IT12L0123456789012345678901"" } },
             ""Amt"": { ""InstdAmt"": 450.75 },
             ""ReqdExctnDt"": { ""Dt"": ""2026-02-20Z"" },
-            ""XpryDt"": { ""Dt"": ""2026-03-10Z"" } }] } } ] } },
+            ""XpryDt"": { ""Dt"": ""2026-03-10Z"" } } }] } ] } },
             ""_links"": {
             ""initialSepaRequestToPayUri"": {
             ""href"": ""https://api-rtp-cb.cstar.pagopa.it/rtp/cb/requests/123"",
@@ -87,7 +88,8 @@
             ""OrgnlEndToEndId"": ""987654321098765432"",
             ""TxSts"": ""RJCT"",
             ""StsRsnInf"": {
-            ""Orgtr"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP04"" } } }
+            ""Orgtr"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP04"" } } },
+            ""Rsn"": { ""Cd"": ""MS03"" }
             },
             ""OrgnlTxRef"": {
             ""PmtTpInf"": {
@@ -181,13 +183,13 @@
             ""CdtrPmtActvtnReqStsRpt"": {
             ""GrpHdr"": {
             ""MsgId"": ""550e8400-e29b-41d4-a716-446655440000"",
-            ""CreDtTm"": ""2026-02-11T14:00:00Z"",
+            ""CreDtTm"": ""2026-02-11T14:00:00.000Z"",
             ""InitgPty"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP04"" } } }
             },
             ""OrgnlGrpInfAndSts"": {
             ""OrgnlMsgId"": ""TestRtpMessageKJ9283KSL01928374650"",
             ""OrgnlMsgNmId"": ""pain.013.001.07"",
-            ""OrgnlCreDtTm"": ""2026-02-12T09:30:00Z""
+            ""OrgnlCreDtTm"": ""2026-02-12T09:30:00.000Z""
             },
             ""OrgnlPmtInfAndSts"": [
             {
@@ -198,7 +200,8 @@
             ""OrgnlEndToEndId"": ""123456789012345678"",
             ""TxSts"": ""ACTC"",
             ""StsRsnInf"": {
-            ""Orgtr"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP04"" } } }
+            ""Orgtr"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP04"" } } },
+            ""AddtlInf"": ""Redirect pending""
             },
             ""OrgnlTxRef"": {
             ""PmtTpInf"": {
@@ -215,7 +218,7 @@
             ""CdtrAcct"": { ""Id"": { ""IBAN"": ""IT12L0123456789012345678901"" } },
             ""Amt"": { ""InstdAmt"": 450.75 },
             ""ReqdExctnDt"": { ""Dt"": ""2026-02-20Z"" },
-            ""XpryDt"": { ""Dt"": ""2026-03-10Z"" } }] } } ] } },
+            ""XpryDt"": { ""Dt"": ""2026-03-10Z"" } } }] } ] } },
             ""_links"": {
             ""initialSepaRequestToPayUri"": {
             ""href"": ""https://api-rtp-cb.cstar.pagopa.it/rtp/cb/requests/123"",
@@ -236,13 +239,13 @@
             ""CdtrPmtActvtnReqStsRpt"": {
             ""GrpHdr"": {
             ""MsgId"": ""550e8400-e29b-41d4-a716-446655440000"",
-            ""CreDtTm"": ""2026-02-11T14:00:00Z"",
+            ""CreDtTm"": ""2026-02-11T14:00:00.000Z"",
             ""InitgPty"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP04"" } } }
             },
             ""OrgnlGrpInfAndSts"": {
             ""OrgnlMsgId"": ""TestRtpMessageKJ9283KSL01928374650"",
             ""OrgnlMsgNmId"": ""pain.013.001.07"",
-            ""OrgnlCreDtTm"": ""2026-02-12T09:30:00Z""
+            ""OrgnlCreDtTm"": ""2026-02-12T09:30:00.000Z""
             },
             ""OrgnlPmtInfAndSts"": [
             {
@@ -253,7 +256,8 @@
             ""OrgnlEndToEndId"": ""123456789012345678"",
             ""TxSts"": ""ACTC"",
             ""StsRsnInf"": {
-            ""Orgtr"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP04"" } } }
+            ""Orgtr"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP04"" } } },
+            ""AddtlInf"": ""Redirect pending""
             },
             ""OrgnlTxRef"": {
             ""PmtTpInf"": {
@@ -270,7 +274,7 @@
             ""CdtrAcct"": { ""Id"": { ""IBAN"": ""IT12L0123456789012345678901"" } },
             ""Amt"": { ""InstdAmt"": 450.75 },
             ""ReqdExctnDt"": { ""Dt"": ""2026-02-20Z"" },
-            ""XpryDt"": { ""Dt"": ""2026-03-10Z"" } }] } } ] } },
+            ""XpryDt"": { ""Dt"": ""2026-03-10Z"" } } }] } ] } },
             ""_links"": {
             ""initialSepaRequestToPayUri"": {
             ""href"": ""https://api-rtp-cb.cstar.pagopa.it/rtp/cb/requests/123"",
@@ -292,13 +296,13 @@
             ""CdtrPmtActvtnReqStsRpt"": {
             ""GrpHdr"": {
             ""MsgId"": ""990e8400-e29b-41d4-a716-446655449999"",
-            ""CreDtTm"": ""2026-02-11T14:05:00Z"",
+            ""CreDtTm"": ""2026-02-11T14:05:00.000Z"",
             ""InitgPty"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP04"" } } }
             },
             ""OrgnlGrpInfAndSts"": {
             ""OrgnlMsgId"": ""TestRtpMessageREJ-ORIG-ID"",
             ""OrgnlMsgNmId"": ""pain.013.001.07"",
-            ""OrgnlCreDtTm"": ""2026-02-12T10:00:00Z""
+            ""OrgnlCreDtTm"": ""2026-02-12T10:00:00.000Z""
             },
             ""OrgnlPmtInfAndSts"": [
             {
@@ -309,7 +313,8 @@
             ""OrgnlEndToEndId"": ""987654321098765432"",
             ""TxSts"": ""RJCT"",
             ""StsRsnInf"": {
-            ""Orgtr"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP04"" } } }
+            ""Orgtr"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP04"" } } },
+            ""Rsn"": { ""Cd"": ""MS03"" }
             },
             ""OrgnlTxRef"": {
             ""PmtTpInf"": {
@@ -351,13 +356,13 @@
             ""CdtrPmtActvtnReqStsRpt"": {
             ""GrpHdr"": {
             ""MsgId"": ""990e8400-e29b-41d4-a716-446655449999"",
-            ""CreDtTm"": ""2026-02-11T14:05:00Z"",
+            ""CreDtTm"": ""2026-02-11T14:05:00.000Z"",
             ""InitgPty"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP04"" } } }
             },
             ""OrgnlGrpInfAndSts"": {
             ""OrgnlMsgId"": ""TestRtpMessageREJ-ORIG-ID"",
             ""OrgnlMsgNmId"": ""pain.013.001.07"",
-            ""OrgnlCreDtTm"": ""2026-02-12T10:00:00Z""
+            ""OrgnlCreDtTm"": ""2026-02-12T10:00:00.000Z""
             },
             ""OrgnlPmtInfAndSts"": [
             {
@@ -368,7 +373,8 @@
             ""OrgnlEndToEndId"": ""987654321098765432"",
             ""TxSts"": ""RJCT"",
             ""StsRsnInf"": {
-            ""Orgtr"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP04"" } } }
+            ""Orgtr"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP04"" } } },
+            ""Rsn"": { ""Cd"": ""MS03"" }
             },
             ""OrgnlTxRef"": {
             ""PmtTpInf"": {


### PR DESCRIPTION
### List of changes

- Added `AddtlInf: "Redirect pending"` to `StsRsnInf` for transactions with status `ACTC` in the EPC v4 policy mock (`mock_policy_epc_v4.xml`)
- Added `Rsn: { Cd: "MS03" }` to `StsRsnInf` for transactions with status `RJCT` in the same mock
- Fixed malformed JSON structure: corrected closing bracket sequence from `}] } } ] } }` to `} }] } ] } }` (mismatched nesting in `OrgnlTxRef`)
- Normalized datetime format from `Z` to `.000Z` (e.g. `2026-02-11T14:00:00Z` → `2026-02-11T14:00:00.000Z`) across all `CreDtTm` and `OrgnlCreDtTm` fields in the mock

### Motivation and context

The EPC 4.0 policy mock was missing mandatory fields required by the pain.002 schema:
- `AddtlInf` is needed to convey the redirect reason for `ACTC` transactions
- `Rsn.Cd` (`MS03`) is needed to specify the rejection reason for `RJCT` transactions
- The JSON nesting bug caused parsing errors in consumers of the mock
- The datetime format without milliseconds was causing validation failures against strict ISO 8601 parsers

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [x] DEV
- [x] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
