### PR TITLE
fix: [SRTP-2015] fix mock policy EPC v4.0

### DIFF
--- a/src/srtp/api/test/mock_policy_epc_v4.xml
+++ b/src/srtp/api/test/mock_policy_epc_v4.xml
@@ -16,7 +16,7 @@
             ""GrpHdr"": {
             ""MsgId"": ""550e8400-e29b-41d4-a716-446655440000"",
             ""CreDtTm"": ""2026-02-11T14:00:00.000Z"",
-            ""InitgPty"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP04"" } } }
+            ""InitgPty"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP05"" } } }
             },
             ""OrgnlGrpInfAndSts"": {
             ""OrgnlMsgId"": ""TestRtpMessageKJ9283KSL01928374650"",
@@ -32,7 +32,7 @@
             ""OrgnlEndToEndId"": ""123456789012345678"",
             ""TxSts"": ""ACTC"",
             ""StsRsnInf"": {
-            ""Orgtr"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP04"" } } },
+            ""Orgtr"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP05"" } } },
             ""AddtlInf"": ""Redirect pending""
             },
             ""OrgnlTxRef"": {
@@ -45,8 +45,8 @@
             ""Id"": { ""OrgId"": { ""Othr"": { ""Id"": ""TRX-ID-112233"", ""SchmeNm"": { ""Cd"": ""BOID"" } } } },
             ""Nm"": ""Azienda Creditrice S.p.A.""
             },
-            ""DbtrAgt"": { ""FinInstnId"": { ""BICFI"": ""MOCKSP04"" } },
-            ""CdtrAgt"": { ""FinInstnId"": { ""BICFI"": ""MOCKSP04"" } },
+            ""DbtrAgt"": { ""FinInstnId"": { ""BICFI"": ""MOCKSP05"" } },
+            ""CdtrAgt"": { ""FinInstnId"": { ""BICFI"": ""MOCKSP05"" } },
             ""CdtrAcct"": { ""Id"": { ""IBAN"": ""IT12L0123456789012345678901"" } },
             ""Amt"": { ""InstdAmt"": 450.75 },
             ""ReqdExctnDt"": { ""Dt"": ""2026-02-20Z"" },
@@ -72,7 +72,7 @@
             ""GrpHdr"": {
             ""MsgId"": ""990e8400-e29b-41d4-a716-446655449999"",
             ""CreDtTm"": ""2026-02-11T14:05:00.000Z"",
-            ""InitgPty"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP04"" } } }
+            ""InitgPty"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP05"" } } }
             },
             ""OrgnlGrpInfAndSts"": {
             ""OrgnlMsgId"": ""TestRtpMessageREJ-ORIG-ID"",
@@ -88,7 +88,7 @@
             ""OrgnlEndToEndId"": ""987654321098765432"",
             ""TxSts"": ""RJCT"",
             ""StsRsnInf"": {
-            ""Orgtr"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP04"" } } },
+            ""Orgtr"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP05"" } } },
             ""Rsn"": { ""Cd"": ""MS03"" }
             },
             ""OrgnlTxRef"": {
@@ -104,8 +104,8 @@
             ""Dbtr"": {
             ""Id"": { ""PrvtId"": { ""Othr"": { ""Id"": ""TRX-REJ-999"", ""SchmeNm"": { ""Cd"": ""POID"" } } } }
             },
-            ""DbtrAgt"": { ""FinInstnId"": { ""BICFI"": ""MOCKSP04"" } },
-            ""CdtrAgt"": { ""FinInstnId"": { ""BICFI"": ""MOCKSP04"" } },
+            ""DbtrAgt"": { ""FinInstnId"": { ""BICFI"": ""MOCKSP05"" } },
+            ""CdtrAgt"": { ""FinInstnId"": { ""BICFI"": ""MOCKSP05"" } },
             ""CdtrAcct"": { ""Id"": { ""IBAN"": ""IT00X0123456789012345678901"" } },
             ""Amt"": { ""InstdAmt"": 120.0 },
             ""ReqdExctnDt"": { ""Dt"": ""2026-02-15Z"" },
@@ -184,7 +184,7 @@
             ""GrpHdr"": {
             ""MsgId"": ""550e8400-e29b-41d4-a716-446655440000"",
             ""CreDtTm"": ""2026-02-11T14:00:00.000Z"",
-            ""InitgPty"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP04"" } } }
+            ""InitgPty"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP05"" } } }
             },
             ""OrgnlGrpInfAndSts"": {
             ""OrgnlMsgId"": ""TestRtpMessageKJ9283KSL01928374650"",
@@ -200,7 +200,7 @@
             ""OrgnlEndToEndId"": ""123456789012345678"",
             ""TxSts"": ""ACTC"",
             ""StsRsnInf"": {
-            ""Orgtr"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP04"" } } },
+            ""Orgtr"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP05"" } } },
             ""AddtlInf"": ""Redirect pending""
             },
             ""OrgnlTxRef"": {
@@ -213,16 +213,12 @@
             ""Id"": { ""OrgId"": { ""Othr"": { ""Id"": ""TRX-ID-112233"", ""SchmeNm"": { ""Cd"": ""BOID"" } } } },
             ""Nm"": ""Azienda Creditrice S.p.A.""
             },
-            ""DbtrAgt"": { ""FinInstnId"": { ""BICFI"": ""MOCKSP04"" } },
-            ""CdtrAgt"": { ""FinInstnId"": { ""BICFI"": ""MOCKSP04"" } },
+            ""DbtrAgt"": { ""FinInstnId"": { ""BICFI"": ""MOCKSP05"" } },
+            ""CdtrAgt"": { ""FinInstnId"": { ""BICFI"": ""MOCKSP05"" } },
             ""CdtrAcct"": { ""Id"": { ""IBAN"": ""IT12L0123456789012345678901"" } },
             ""Amt"": { ""InstdAmt"": 450.75 },
             ""ReqdExctnDt"": { ""Dt"": ""2026-02-20Z"" },
-            ""XpryDt"": { ""Dt"": ""2026-03-10Z"" } } }] } ] } },
-            ""_links"": {
-            ""initialSepaRequestToPayUri"": {
-            ""href"": ""https://api-rtp-cb.cstar.pagopa.it/rtp/cb/requests/123"",
-            ""templated"": false } } }";
+            ""XpryDt"": { ""Dt"": ""2026-03-10Z"" } } }] } ] } } }";
             }</set-body>
         </return-response>
       </when>
@@ -240,7 +236,7 @@
             ""GrpHdr"": {
             ""MsgId"": ""550e8400-e29b-41d4-a716-446655440000"",
             ""CreDtTm"": ""2026-02-11T14:00:00.000Z"",
-            ""InitgPty"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP04"" } } }
+            ""InitgPty"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP05"" } } }
             },
             ""OrgnlGrpInfAndSts"": {
             ""OrgnlMsgId"": ""TestRtpMessageKJ9283KSL01928374650"",
@@ -256,7 +252,7 @@
             ""OrgnlEndToEndId"": ""123456789012345678"",
             ""TxSts"": ""ACTC"",
             ""StsRsnInf"": {
-            ""Orgtr"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP04"" } } },
+            ""Orgtr"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP05"" } } },
             ""AddtlInf"": ""Redirect pending""
             },
             ""OrgnlTxRef"": {
@@ -269,8 +265,8 @@
             ""Id"": { ""OrgId"": { ""Othr"": { ""Id"": ""TRX-ID-112233"", ""SchmeNm"": { ""Cd"": ""BOID"" } } } },
             ""Nm"": ""Azienda Creditrice S.p.A.""
             },
-            ""DbtrAgt"": { ""FinInstnId"": { ""BICFI"": ""MOCKSP04"" } },
-            ""CdtrAgt"": { ""FinInstnId"": { ""BICFI"": ""MOCKSP04"" } },
+            ""DbtrAgt"": { ""FinInstnId"": { ""BICFI"": ""MOCKSP05"" } },
+            ""CdtrAgt"": { ""FinInstnId"": { ""BICFI"": ""MOCKSP05"" } },
             ""CdtrAcct"": { ""Id"": { ""IBAN"": ""IT12L0123456789012345678901"" } },
             ""Amt"": { ""InstdAmt"": 450.75 },
             ""ReqdExctnDt"": { ""Dt"": ""2026-02-20Z"" },
@@ -297,7 +293,7 @@
             ""GrpHdr"": {
             ""MsgId"": ""990e8400-e29b-41d4-a716-446655449999"",
             ""CreDtTm"": ""2026-02-11T14:05:00.000Z"",
-            ""InitgPty"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP04"" } } }
+            ""InitgPty"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP05"" } } }
             },
             ""OrgnlGrpInfAndSts"": {
             ""OrgnlMsgId"": ""TestRtpMessageREJ-ORIG-ID"",
@@ -313,7 +309,7 @@
             ""OrgnlEndToEndId"": ""987654321098765432"",
             ""TxSts"": ""RJCT"",
             ""StsRsnInf"": {
-            ""Orgtr"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP04"" } } },
+            ""Orgtr"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP05"" } } },
             ""Rsn"": { ""Cd"": ""MS03"" }
             },
             ""OrgnlTxRef"": {
@@ -329,8 +325,8 @@
             ""Dbtr"": {
             ""Id"": { ""PrvtId"": { ""Othr"": { ""Id"": ""TRX-REJ-999"", ""SchmeNm"": { ""Cd"": ""POID"" } } } }
             },
-            ""DbtrAgt"": { ""FinInstnId"": { ""BICFI"": ""MOCKSP04"" } },
-            ""CdtrAgt"": { ""FinInstnId"": { ""BICFI"": ""MOCKSP04"" } },
+            ""DbtrAgt"": { ""FinInstnId"": { ""BICFI"": ""MOCKSP05"" } },
+            ""CdtrAgt"": { ""FinInstnId"": { ""BICFI"": ""MOCKSP05"" } },
             ""CdtrAcct"": { ""Id"": { ""IBAN"": ""IT00X0123456789012345678901"" } },
             ""Amt"": { ""InstdAmt"": 120.0 },
             ""ReqdExctnDt"": { ""Dt"": ""2026-02-15Z"" },
@@ -357,7 +353,7 @@
             ""GrpHdr"": {
             ""MsgId"": ""990e8400-e29b-41d4-a716-446655449999"",
             ""CreDtTm"": ""2026-02-11T14:05:00.000Z"",
-            ""InitgPty"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP04"" } } }
+            ""InitgPty"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP05"" } } }
             },
             ""OrgnlGrpInfAndSts"": {
             ""OrgnlMsgId"": ""TestRtpMessageREJ-ORIG-ID"",
@@ -373,7 +369,7 @@
             ""OrgnlEndToEndId"": ""987654321098765432"",
             ""TxSts"": ""RJCT"",
             ""StsRsnInf"": {
-            ""Orgtr"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP04"" } } },
+            ""Orgtr"": { ""Id"": { ""OrgId"": { ""AnyBIC"": ""MOCKSP05"" } } },
             ""Rsn"": { ""Cd"": ""MS03"" }
             },
             ""OrgnlTxRef"": {
@@ -389,16 +385,12 @@
             ""Dbtr"": {
             ""Id"": { ""PrvtId"": { ""Othr"": { ""Id"": ""TRX-REJ-999"", ""SchmeNm"": { ""Cd"": ""POID"" } } } }
             },
-            ""DbtrAgt"": { ""FinInstnId"": { ""BICFI"": ""MOCKSP04"" } },
-            ""CdtrAgt"": { ""FinInstnId"": { ""BICFI"": ""MOCKSP04"" } },
+            ""DbtrAgt"": { ""FinInstnId"": { ""BICFI"": ""MOCKSP05"" } },
+            ""CdtrAgt"": { ""FinInstnId"": { ""BICFI"": ""MOCKSP05"" } },
             ""CdtrAcct"": { ""Id"": { ""IBAN"": ""IT00X0123456789012345678901"" } },
             ""Amt"": { ""InstdAmt"": 120.0 },
             ""ReqdExctnDt"": { ""Dt"": ""2026-02-15Z"" },
-            ""XpryDt"": { ""Dt"": ""2026-03-01Z"" } } } } ] } },
-            ""_links"": {
-            ""initialSepaRequestToPayUri"": {
-            ""href"": ""https://api-rtp-cb.cstar.pagopa.it/rtp/cb/requests/123"",
-            ""templated"": false } } }";
+            ""XpryDt"": { ""Dt"": ""2026-03-01Z"" } } } } ] } } }";
             }</set-body>
         </return-response>
       </when>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

- Fixed the `postRequestToPayRequests-v4`/`postRequestToPayCancellationRequest-v4` mock policy (`src/srtp/api/test/mock_policy_epc_v4.xml`) used by the `rtp-mock-v4` APIM API:
  - The fiscal code `MFNCRG01B20B521C` responded with an exact duplicate of the ACTC (`DDSRSC61L26M520O`) response body, including the `_links` object. It now returns the same ACTC-compliant body **without** the `_links` object, so it actually represents the "no links" test scenario.
  - The fiscal code `PCSRFO44D22G286S` responded with an exact duplicate of the RJCT (`WCZQJA98L17M134D`) response body, including the `_links` object. It now returns the same RJCT-compliant body **without** the `_links` object, so it actually represents the "RJCT no links" test scenario.
  - Renamed the mocked BIC `MOCKSP04` to `MOCKSP05` across all response bodies in the file.

### Motivation and context

The EPC v4.0 mock policy (`mock_policy_epc_v4.xml`) is meant to expose 7 distinct fiscal-code-driven test scenarios (ACTC, RJCT, no-links, extra-field, server-error, RJCT-extra-field, RJCT-no-links). Two of the v4 fiscal codes were byte-for-byte copies of other scenarios instead of the intended "no links" variants, so client integrations testing against those codes were never actually exercising a response missing the `_links` object. This aligns the v4 mock behavior with the v3 one and with the EPC v4.0 response schema.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [x] DEV
- [x] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->