### PR TITLE
feat: [SRTP-2038] Create Cancel v2 Policy

### DIFF
--- a/src/srtp/99_locals.tf
+++ b/src/srtp/99_locals.tf
@@ -446,7 +446,7 @@ locals {
       postRequestToPayCancellationRequest-v4 = var.env_short == "p" ? null : {
         api_name     = "rtp-mock-v4"
         operation_id = "postRequestToPayCancellationRequest"
-        xml_content  = file("./api/test/mock_policy_epc_v4.xml")
+        xml_content  = file("./api/test/mock_policy_cancel_epc_v4.xml")
       }
       processGpdMessage = var.env_short == "p" ? null : {
         api_name    = "rtp-gpd-message-mock"

--- a/src/srtp/api/test/mock_policy_cancel_epc_v4.xml
+++ b/src/srtp/api/test/mock_policy_cancel_epc_v4.xml
@@ -2,7 +2,7 @@
   <inbound>
     <base />
     <choose>
-      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;999999999999999999000&quot;))">
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;999999999999999000&quot;))">
         <return-response>
           <set-status code="201" reason="Created" />
           <set-header name="Content-Type" exists-action="override">
@@ -11,7 +11,7 @@
           <set-body template="none">{}</set-body>
         </return-response>
       </when>
-      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;999999999999999999001&quot;))">
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;999999999999999001&quot;))">
         <return-response>
           <set-status code="201" reason="Created" />
           <set-header name="Content-Type" exists-action="override">
@@ -20,7 +20,7 @@
           <set-body template="none">"Test string"</set-body>
         </return-response>
       </when>
-      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;999999999999999999002&quot;))">
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;999999999999999002&quot;))">
         <return-response>
           <set-status code="201" reason="Created" />
           <set-header name="Content-Type" exists-action="override">
@@ -29,7 +29,7 @@
           <set-body template="none">{"test": "test_value"}</set-body>
         </return-response>
       </when>
-      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;999999999999999999003&quot;))">
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;999999999999999003&quot;))">
         <return-response>
           <set-status code="201" reason="Created" />
           <set-header name="Content-Type" exists-action="override">
@@ -239,7 +239,7 @@
 }</set-body>
         </return-response>
       </when>
-      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;999999999999999999004&quot;))">
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;999999999999999004&quot;))">
         <return-response>
           <set-status code="201" reason="Created" />
           <set-header name="Content-Type" exists-action="override">
@@ -446,7 +446,7 @@
 }</set-body>
         </return-response>
       </when>
-      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;999999999999999999005&quot;))">
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;999999999999999005&quot;))">
         <return-response>
           <set-status code="201" reason="Created" />
           <set-header name="Content-Type" exists-action="override">
@@ -656,7 +656,7 @@
 }</set-body>
         </return-response>
       </when>
-      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;999999999999999999006&quot;))">
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;999999999999999006&quot;))">
         <return-response>
           <set-status code="400" reason="Bad request" />
           <set-header name="Content-Type" exists-action="override">
@@ -692,7 +692,7 @@
 }</set-body>
         </return-response>
       </when>
-      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;999999999999999999007&quot;))">
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;999999999999999007&quot;))">
         <return-response>
           <set-status code="401" reason="Unauthorized" />
           <set-header name="Content-Type" exists-action="override">
@@ -728,7 +728,7 @@
 }</set-body>
         </return-response>
       </when>
-      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;999999999999999999008&quot;))">
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;999999999999999008&quot;))">
         <return-response>
           <set-status code="404" reason="Not Found" />
           <set-header name="Content-Type" exists-action="override">
@@ -764,7 +764,7 @@
 }</set-body>
         </return-response>
       </when>
-      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;999999999999999999009&quot;))">
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;999999999999999009&quot;))">
         <return-response>
           <set-status code="406" reason="Not Acceptable" />
           <set-header name="Content-Type" exists-action="override">
@@ -800,7 +800,7 @@
 }</set-body>
         </return-response>
       </when>
-      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;999999999999999999010&quot;))">
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;999999999999999010&quot;))">
         <return-response>
           <set-status code="410" reason="Gone" />
           <set-header name="Content-Type" exists-action="override">
@@ -836,7 +836,7 @@
 }</set-body>
         </return-response>
       </when>
-      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;999999999999999999011&quot;))">
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;999999999999999011&quot;))">
         <return-response>
           <set-status code="415" reason="Unsupported Media Type" />
           <set-header name="Content-Type" exists-action="override">
@@ -872,7 +872,7 @@
 }</set-body>
         </return-response>
       </when>
-      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;999999999999999999012&quot;))">
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;999999999999999012&quot;))">
         <return-response>
           <set-status code="422" reason="Unprocessable Entity" />
           <set-header name="Content-Type" exists-action="override">
@@ -908,7 +908,7 @@
 }</set-body>
         </return-response>
       </when>
-      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;999999999999999999013&quot;))">
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;999999999999999013&quot;))">
         <return-response>
           <set-status code="429" reason="Too Many Requests" />
           <set-header name="Content-Type" exists-action="override">
@@ -944,7 +944,7 @@
 }</set-body>
         </return-response>
       </when>
-      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;999999999999999999014&quot;))">
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;999999999999999014&quot;))">
         <return-response>
           <set-status code="201" reason="Created" />
           <set-header name="Content-Type" exists-action="override">
@@ -1155,7 +1155,7 @@
 }</set-body>
         </return-response>
       </when>
-      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;999999999999999999015&quot;))">
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;999999999999999015&quot;))">
         <return-response>
           <set-status code="201" reason="Created" />
           <set-header name="Content-Type" exists-action="override">

--- a/src/srtp/api/test/mock_policy_cancel_epc_v4.xml
+++ b/src/srtp/api/test/mock_policy_cancel_epc_v4.xml
@@ -1,0 +1,967 @@
+<policies>
+  <inbound>
+    <base />
+    <choose>
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;999999999999999999000&quot;))">
+        <return-response>
+          <set-status code="201" reason="Created" />
+          <set-header name="Content-Type" exists-action="override">
+            <value>application/json</value>
+          </set-header>
+          <set-body template="none">{}</set-body>
+        </return-response>
+      </when>
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;999999999999999999001&quot;))">
+        <return-response>
+          <set-status code="201" reason="Created" />
+          <set-header name="Content-Type" exists-action="override">
+            <value>application/json</value>
+          </set-header>
+          <set-body template="none">"Test string"</set-body>
+        </return-response>
+      </when>
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;999999999999999999002&quot;))">
+        <return-response>
+          <set-status code="201" reason="Created" />
+          <set-header name="Content-Type" exists-action="override">
+            <value>application/json</value>
+          </set-header>
+          <set-body template="none">{"test": "test_value"}</set-body>
+        </return-response>
+      </when>
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;999999999999999999003&quot;))">
+        <return-response>
+          <set-status code="201" reason="Created" />
+          <set-header name="Content-Type" exists-action="override">
+            <value>application/json</value>
+          </set-header>
+          <set-body template="none">{
+  "resourceId": "string",
+  "SepaRequestToPayCancellationResponse": {
+    "Document": {
+      "RsltnOfInvstgtn": {
+        "Assgnmt": {
+          "Id": "string",
+          "Assgnr": {
+            "Pty": {
+              "Id": {
+                "OrgId": {
+                  "AnyBIC": "G97MXMNJ",
+                  "LEI": "EDNKSSR7OJFCK5HGE391",
+                  "Othr": {
+                    "Id": "string",
+                    "SchmeNm": {
+                      "Cd": "BANK"
+                    },
+                    "Issr": "string"
+                  }
+                }
+              }
+            }
+          },
+          "Assgne": {
+            "Pty": {
+              "Id": {
+                "OrgId": {
+                  "AnyBIC": "EJ7VIM2P6DZ",
+                  "LEI": "N84IA01SPUZDV8KSO957",
+                  "Othr": {
+                    "Id": "string",
+                    "SchmeNm": {
+                      "Cd": "BANK"
+                    },
+                    "Issr": "string"
+                  }
+                }
+              }
+            }
+          },
+          "CreDtTm": "2026-07-07T12:24:46.224Z"
+        },
+        "Sts": {
+          "Conf": "CNCL"
+        },
+        "CxlDtls": {
+          "OrgnlPmtInfAndSts": [
+            {
+              "OrgnlPmtInfId": "string",
+              "TxInfAndSts": [
+                {
+                  "OrgnlInstrId": "string",
+                  "OrgnlEndToEndId": "string"
+                }
+              ]
+            }
+          ],
+          "TxInfAndSts": [
+            {
+              "CxlStsId": "string",
+              "OrgnlGrpInf": {
+                "OrgnlMsgId": "string",
+                "OrgnlMsgNmId": "string",
+                "OrgnlCreDtTm": "2026-07-07T12:24:46.224Z"
+              },
+              "OrgnlInstrId": "string",
+              "OrgnlEndToEndId": "string",
+              "OrgnlTxId": "string",
+              "TxCxlSts": "ACCR",
+              "CxlStsRsnInf": {
+                "Orgtr": {
+                  "Id": {
+                    "OrgId": {
+                      "AnyBIC": "JYSVKCV4529",
+                      "LEI": "LGDFSQ844N6JZIG1JY44",
+                      "Othr": {
+                        "Id": "string",
+                        "SchmeNm": {
+                          "Cd": "BANK"
+                        },
+                        "Issr": "string"
+                      }
+                    }
+                  }
+                },
+                "AddtlInf": [
+                  "string"
+                ]
+              },
+              "RsltnRltdInf": {
+                "Chrgs": {
+                  "Amt": 0.01,
+                  "Agt": {
+                    "FinInstnId": {
+                      "BICFI": "4B57ZXNU",
+                      "LEI": "B74OLVW7LP0P6A4VPE31",
+                      "Othr": {
+                        "Id": "string",
+                        "SchmeNm": {
+                          "Cd": "stri"
+                        },
+                        "Issr": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              "OrgnlTxRef": {
+                "Amt": {
+                  "InstdAmt": 999999999.99
+                },
+                "ReqdExctnDt": {
+                  "Dt": "string"
+                },
+                "PmtTpInf": {
+                  "SvcLvl": {
+                    "Cd": "SEPA"
+                  },
+                  "LclInstrm": {
+                    "Cd": "string"
+                  }
+                },
+                "RmtInf": {
+                  "Ustrd": "string",
+                  "Strd": {
+                    "RfrdDocAmt": {
+                      "CdtNoteAmt": 999999999.99
+                    },
+                    "CdtrRefInf": {
+                      "Tp": {
+                        "CdOrPrtry": {
+                          "Cd": "SCOR"
+                        },
+                        "Issr": "string"
+                      },
+                      "Ref": "string"
+                    }
+                  }
+                },
+                "DbtrAgt": {
+                  "FinInstnId": {
+                    "BICFI": "22O9XJ9ME5V",
+                    "LEI": "0RP0MY5ZOJSWRKAQPQ30",
+                    "Othr": {
+                      "Id": "string",
+                      "SchmeNm": {
+                        "Cd": "stri"
+                      },
+                      "Issr": "string"
+                    }
+                  }
+                },
+                "CdtrAgt": {
+                  "FinInstnId": {
+                    "BICFI": "MMI1VJUKRS9",
+                    "LEI": "M3OKJHV9NXIYJ45YZL45",
+                    "Othr": {
+                      "Id": "string",
+                      "SchmeNm": {
+                        "Cd": "stri"
+                      },
+                      "Issr": "string"
+                    }
+                  }
+                },
+                "Cdtr": {
+                  "Pty": {
+                    "Nm": "string",
+                    "Id": {
+                      "OrgId": {
+                        "AnyBIC": "9RG4IV5X",
+                        "LEI": "MZGAR0ZD0SJXT4ERHT80",
+                        "Othr": {
+                          "Id": "string",
+                          "SchmeNm": {
+                            "Cd": "BANK"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "CdtrAcct": {
+                  "Id": {
+                    "IBAN": "EQ33IE"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "_links": {
+    "initialSepaRequestToPayUri": {
+      "href": "string",
+      "templated": false
+    }
+  }
+}</set-body>
+        </return-response>
+      </when>
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;999999999999999999004&quot;))">
+        <return-response>
+          <set-status code="201" reason="Created" />
+          <set-header name="Content-Type" exists-action="override">
+            <value>application/json</value>
+          </set-header>
+          <set-body template="none">{
+  "resourceId": "string",
+  "SepaRequestToPayCancellationResponse": {
+    "Document": {
+      "RsltnOfInvstgtn": {
+        "Assgnmt": {
+          "Id": "string",
+          "Assgnr": {
+            "Pty": {
+              "Id": {
+                "OrgId": {
+                  "AnyBIC": "G97MXMNJ",
+                  "LEI": "EDNKSSR7OJFCK5HGE391",
+                  "Othr": {
+                    "Id": "string",
+                    "SchmeNm": {
+                      "Cd": "BANK"
+                    },
+                    "Issr": "string"
+                  }
+                }
+              }
+            }
+          },
+          "Assgne": {
+            "Pty": {
+              "Id": {
+                "OrgId": {
+                  "AnyBIC": "EJ7VIM2P6DZ",
+                  "LEI": "N84IA01SPUZDV8KSO957",
+                  "Othr": {
+                    "Id": "string",
+                    "SchmeNm": {
+                      "Cd": "BANK"
+                    },
+                    "Issr": "string"
+                  }
+                }
+              }
+            }
+          },
+          "CreDtTm": "2026-07-07T12:24:46.224Z"
+        },
+        "CxlDtls": {
+          "OrgnlPmtInfAndSts": [
+            {
+              "OrgnlPmtInfId": "string",
+              "TxInfAndSts": [
+                {
+                  "OrgnlInstrId": "string",
+                  "OrgnlEndToEndId": "string"
+                }
+              ]
+            }
+          ],
+          "TxInfAndSts": [
+            {
+              "CxlStsId": "string",
+              "OrgnlGrpInf": {
+                "OrgnlMsgId": "string",
+                "OrgnlMsgNmId": "string",
+                "OrgnlCreDtTm": "2026-07-07T12:24:46.224Z"
+              },
+              "OrgnlInstrId": "string",
+              "OrgnlEndToEndId": "string",
+              "OrgnlTxId": "string",
+              "TxCxlSts": "ACCR",
+              "CxlStsRsnInf": {
+                "Orgtr": {
+                  "Id": {
+                    "OrgId": {
+                      "AnyBIC": "JYSVKCV4529",
+                      "LEI": "LGDFSQ844N6JZIG1JY44",
+                      "Othr": {
+                        "Id": "string",
+                        "SchmeNm": {
+                          "Cd": "BANK"
+                        },
+                        "Issr": "string"
+                      }
+                    }
+                  }
+                },
+                "AddtlInf": [
+                  "string"
+                ]
+              },
+              "RsltnRltdInf": {
+                "Chrgs": {
+                  "Amt": 0.01,
+                  "Agt": {
+                    "FinInstnId": {
+                      "BICFI": "4B57ZXNU",
+                      "LEI": "B74OLVW7LP0P6A4VPE31",
+                      "Othr": {
+                        "Id": "string",
+                        "SchmeNm": {
+                          "Cd": "stri"
+                        },
+                        "Issr": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              "OrgnlTxRef": {
+                "Amt": {
+                  "InstdAmt": 999999999.99
+                },
+                "ReqdExctnDt": {
+                  "Dt": "string"
+                },
+                "PmtTpInf": {
+                  "SvcLvl": {
+                    "Cd": "SEPA"
+                  },
+                  "LclInstrm": {
+                    "Cd": "string"
+                  }
+                },
+                "RmtInf": {
+                  "Ustrd": "string",
+                  "Strd": {
+                    "RfrdDocAmt": {
+                      "CdtNoteAmt": 999999999.99
+                    },
+                    "CdtrRefInf": {
+                      "Tp": {
+                        "CdOrPrtry": {
+                          "Cd": "SCOR"
+                        },
+                        "Issr": "string"
+                      },
+                      "Ref": "string"
+                    }
+                  }
+                },
+                "DbtrAgt": {
+                  "FinInstnId": {
+                    "BICFI": "22O9XJ9ME5V",
+                    "LEI": "0RP0MY5ZOJSWRKAQPQ30",
+                    "Othr": {
+                      "Id": "string",
+                      "SchmeNm": {
+                        "Cd": "stri"
+                      },
+                      "Issr": "string"
+                    }
+                  }
+                },
+                "CdtrAgt": {
+                  "FinInstnId": {
+                    "BICFI": "MMI1VJUKRS9",
+                    "LEI": "M3OKJHV9NXIYJ45YZL45",
+                    "Othr": {
+                      "Id": "string",
+                      "SchmeNm": {
+                        "Cd": "stri"
+                      },
+                      "Issr": "string"
+                    }
+                  }
+                },
+                "Cdtr": {
+                  "Pty": {
+                    "Nm": "string",
+                    "Id": {
+                      "OrgId": {
+                        "AnyBIC": "9RG4IV5X",
+                        "LEI": "MZGAR0ZD0SJXT4ERHT80",
+                        "Othr": {
+                          "Id": "string",
+                          "SchmeNm": {
+                            "Cd": "BANK"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "CdtrAcct": {
+                  "Id": {
+                    "IBAN": "EQ33IE"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "_links": {
+    "initialSepaRequestToPayUri": {
+      "href": "string",
+      "templated": false
+    }
+  }
+}</set-body>
+        </return-response>
+      </when>
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;999999999999999999005&quot;))">
+        <return-response>
+          <set-status code="201" reason="Created" />
+          <set-header name="Content-Type" exists-action="override">
+            <value>application/json</value>
+          </set-header>
+          <set-body template="none">{
+  "resourceId": "string",
+  "SepaRequestToPayCancellationResponse": {
+    "Document": {
+      "RsltnOfInvstgtn": {
+        "Assgnmt": {
+          "Id": "string",
+          "Assgnr": {
+            "Pty": {
+              "Id": {
+                "OrgId": {
+                  "AnyBIC": "G97MXMNJ",
+                  "LEI": "EDNKSSR7OJFCK5HGE391",
+                  "Othr": {
+                    "Id": "string",
+                    "SchmeNm": {
+                      "Cd": "BANK"
+                    },
+                    "Issr": "string"
+                  }
+                }
+              }
+            }
+          },
+          "Assgne": {
+            "Pty": {
+              "Id": {
+                "OrgId": {
+                  "AnyBIC": "EJ7VIM2P6DZ",
+                  "LEI": "N84IA01SPUZDV8KSO957",
+                  "Othr": {
+                    "Id": "string",
+                    "SchmeNm": {
+                      "Cd": "BANK"
+                    },
+                    "Issr": "string"
+                  }
+                }
+              }
+            }
+          },
+          "CreDtTm": "2026-07-07T12:24:46.224Z"
+        },
+        "Sts": {
+          "Conf": "RJCR"
+        },
+        "CxlDtls": {
+          "OrgnlPmtInfAndSts": [
+            {
+              "OrgnlPmtInfId": "string",
+              "TxInfAndSts": [
+                {
+                  "OrgnlInstrId": "string",
+                  "OrgnlEndToEndId": "string"
+                }
+              ]
+            }
+          ],
+          "TxInfAndSts": [
+            {
+              "CxlStsId": "string",
+              "OrgnlGrpInf": {
+                "OrgnlMsgId": "string",
+                "OrgnlMsgNmId": "string",
+                "OrgnlCreDtTm": "2026-07-07T12:24:46.224Z"
+              },
+              "OrgnlInstrId": "string",
+              "OrgnlEndToEndId": "string",
+              "OrgnlTxId": "string",
+              "TxCxlSts": "ACCR",
+              "CxlStsRsnInf": {
+                "Orgtr": {
+                  "Id": {
+                    "OrgId": {
+                      "AnyBIC": "JYSVKCV4529",
+                      "LEI": "LGDFSQ844N6JZIG1JY44",
+                      "Othr": {
+                        "Id": "string",
+                        "SchmeNm": {
+                          "Cd": "BANK"
+                        },
+                        "Issr": "string"
+                      }
+                    }
+                  }
+                },
+                "AddtlInf": [
+                  "string"
+                ]
+              },
+              "RsltnRltdInf": {
+                "Chrgs": {
+                  "Amt": 0.01,
+                  "Agt": {
+                    "FinInstnId": {
+                      "BICFI": "4B57ZXNU",
+                      "LEI": "B74OLVW7LP0P6A4VPE31",
+                      "Othr": {
+                        "Id": "string",
+                        "SchmeNm": {
+                          "Cd": "stri"
+                        },
+                        "Issr": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              "OrgnlTxRef": {
+                "Amt": {
+                  "InstdAmt": 999999999.99
+                },
+                "ReqdExctnDt": {
+                  "Dt": "string"
+                },
+                "PmtTpInf": {
+                  "SvcLvl": {
+                    "Cd": "SEPA"
+                  },
+                  "LclInstrm": {
+                    "Cd": "string"
+                  }
+                },
+                "RmtInf": {
+                  "Ustrd": "string",
+                  "Strd": {
+                    "RfrdDocAmt": {
+                      "CdtNoteAmt": 999999999.99
+                    },
+                    "CdtrRefInf": {
+                      "Tp": {
+                        "CdOrPrtry": {
+                          "Cd": "SCOR"
+                        },
+                        "Issr": "string"
+                      },
+                      "Ref": "string"
+                    }
+                  }
+                },
+                "DbtrAgt": {
+                  "FinInstnId": {
+                    "BICFI": "22O9XJ9ME5V",
+                    "LEI": "0RP0MY5ZOJSWRKAQPQ30",
+                    "Othr": {
+                      "Id": "string",
+                      "SchmeNm": {
+                        "Cd": "stri"
+                      },
+                      "Issr": "string"
+                    }
+                  }
+                },
+                "CdtrAgt": {
+                  "FinInstnId": {
+                    "BICFI": "MMI1VJUKRS9",
+                    "LEI": "M3OKJHV9NXIYJ45YZL45",
+                    "Othr": {
+                      "Id": "string",
+                      "SchmeNm": {
+                        "Cd": "stri"
+                      },
+                      "Issr": "string"
+                    }
+                  }
+                },
+                "Cdtr": {
+                  "Pty": {
+                    "Nm": "string",
+                    "Id": {
+                      "OrgId": {
+                        "AnyBIC": "9RG4IV5X",
+                        "LEI": "MZGAR0ZD0SJXT4ERHT80",
+                        "Othr": {
+                          "Id": "string",
+                          "SchmeNm": {
+                            "Cd": "BANK"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "CdtrAcct": {
+                  "Id": {
+                    "IBAN": "EQ33IE"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "_links": {
+    "initialSepaRequestToPayUri": {
+      "href": "string",
+      "templated": false
+    }
+  }
+}</set-body>
+        </return-response>
+      </when>
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;999999999999999999006&quot;))">
+        <return-response>
+          <set-status code="400" reason="Bad request" />
+          <set-header name="Content-Type" exists-action="override">
+            <value>application/json</value>
+          </set-header>
+          <set-body template="none">{
+  "timestamp": "2026-07-07T12:24:46.230Z",
+  "status": 400,
+  "error": "Bad Request",
+  "message": "Malformed or invalid request body",
+  "path": "string",
+  "details": [
+    {
+      "location": "header",
+      "name": "string",
+      "path": "string",
+      "erroneousValue": "string",
+      "message": "string",
+      "expectedPattern": "string",
+      "expectedValueRange": {
+        "minValue": 0,
+        "maxValue": 0
+      },
+      "expectedValueCount": {
+        "minValue": 0,
+        "maxValue": 0
+      },
+      "expectedEnumeration": [
+        "string"
+      ]
+    }
+  ]
+}</set-body>
+        </return-response>
+      </when>
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;999999999999999999007&quot;))">
+        <return-response>
+          <set-status code="401" reason="Unauthorized" />
+          <set-header name="Content-Type" exists-action="override">
+            <value>application/json</value>
+          </set-header>
+          <set-body template="none">{
+  "timestamp": "2026-07-07T12:24:46.230Z",
+  "status": 401,
+  "error": "Unauthorized",
+  "message": "Missing or invalid authentication credentials",
+  "path": "string",
+  "details": [
+    {
+      "location": "header",
+      "name": "string",
+      "path": "string",
+      "erroneousValue": "string",
+      "message": "string",
+      "expectedPattern": "string",
+      "expectedValueRange": {
+        "minValue": 0,
+        "maxValue": 0
+      },
+      "expectedValueCount": {
+        "minValue": 0,
+        "maxValue": 0
+      },
+      "expectedEnumeration": [
+        "string"
+      ]
+    }
+  ]
+}</set-body>
+        </return-response>
+      </when>
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;999999999999999999008&quot;))">
+        <return-response>
+          <set-status code="404" reason="Not Found" />
+          <set-header name="Content-Type" exists-action="override">
+            <value>application/json</value>
+          </set-header>
+          <set-body template="none">{
+  "timestamp": "2026-07-07T12:24:46.230Z",
+  "status": 404,
+  "error": "Not Found",
+  "message": "Requested resource could not be found",
+  "path": "string",
+  "details": [
+    {
+      "location": "header",
+      "name": "string",
+      "path": "string",
+      "erroneousValue": "string",
+      "message": "string",
+      "expectedPattern": "string",
+      "expectedValueRange": {
+        "minValue": 0,
+        "maxValue": 0
+      },
+      "expectedValueCount": {
+        "minValue": 0,
+        "maxValue": 0
+      },
+      "expectedEnumeration": [
+        "string"
+      ]
+    }
+  ]
+}</set-body>
+        </return-response>
+      </when>
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;999999999999999999009&quot;))">
+        <return-response>
+          <set-status code="406" reason="Not Acceptable" />
+          <set-header name="Content-Type" exists-action="override">
+            <value>application/json</value>
+          </set-header>
+          <set-body template="none">{
+  "timestamp": "2026-07-07T12:24:46.230Z",
+  "status": 406,
+  "error": "Not Acceptable",
+  "message": "Requested media type is not supported",
+  "path": "string",
+  "details": [
+    {
+      "location": "header",
+      "name": "string",
+      "path": "string",
+      "erroneousValue": "string",
+      "message": "string",
+      "expectedPattern": "string",
+      "expectedValueRange": {
+        "minValue": 0,
+        "maxValue": 0
+      },
+      "expectedValueCount": {
+        "minValue": 0,
+        "maxValue": 0
+      },
+      "expectedEnumeration": [
+        "string"
+      ]
+    }
+  ]
+}</set-body>
+        </return-response>
+      </when>
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;999999999999999999010&quot;))">
+        <return-response>
+          <set-status code="410" reason="Gone" />
+          <set-header name="Content-Type" exists-action="override">
+            <value>application/json</value>
+          </set-header>
+          <set-body template="none">{
+  "timestamp": "2026-07-07T12:24:46.230Z",
+  "status": 410,
+  "error": "Gone",
+  "message": "Requested resource is no longer available",
+  "path": "string",
+  "details": [
+    {
+      "location": "header",
+      "name": "string",
+      "path": "string",
+      "erroneousValue": "string",
+      "message": "string",
+      "expectedPattern": "string",
+      "expectedValueRange": {
+        "minValue": 0,
+        "maxValue": 0
+      },
+      "expectedValueCount": {
+        "minValue": 0,
+        "maxValue": 0
+      },
+      "expectedEnumeration": [
+        "string"
+      ]
+    }
+  ]
+}</set-body>
+        </return-response>
+      </when>
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;999999999999999999011&quot;))">
+        <return-response>
+          <set-status code="415" reason="Unsupported Media Type" />
+          <set-header name="Content-Type" exists-action="override">
+            <value>application/json</value>
+          </set-header>
+          <set-body template="none">{
+  "timestamp": "2026-07-07T12:24:46.230Z",
+  "status": 415,
+  "error": "Unsupported Media Type",
+  "message": "Request payload media type is not supported",
+  "path": "string",
+  "details": [
+    {
+      "location": "header",
+      "name": "string",
+      "path": "string",
+      "erroneousValue": "string",
+      "message": "string",
+      "expectedPattern": "string",
+      "expectedValueRange": {
+        "minValue": 0,
+        "maxValue": 0
+      },
+      "expectedValueCount": {
+        "minValue": 0,
+        "maxValue": 0
+      },
+      "expectedEnumeration": [
+        "string"
+      ]
+    }
+  ]
+}</set-body>
+        </return-response>
+      </when>
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;999999999999999999012&quot;))">
+        <return-response>
+          <set-status code="422" reason="Unprocessable Entity" />
+          <set-header name="Content-Type" exists-action="override">
+            <value>application/json</value>
+          </set-header>
+          <set-body template="none">{
+  "timestamp": "2026-07-07T12:24:46.230Z",
+  "status": 422,
+  "error": "Unprocessable Entity",
+  "message": "Request payload failed semantic validation",
+  "path": "string",
+  "details": [
+    {
+      "location": "header",
+      "name": "string",
+      "path": "string",
+      "erroneousValue": "string",
+      "message": "string",
+      "expectedPattern": "string",
+      "expectedValueRange": {
+        "minValue": 0,
+        "maxValue": 0
+      },
+      "expectedValueCount": {
+        "minValue": 0,
+        "maxValue": 0
+      },
+      "expectedEnumeration": [
+        "string"
+      ]
+    }
+  ]
+}</set-body>
+        </return-response>
+      </when>
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;999999999999999999013&quot;))">
+        <return-response>
+          <set-status code="429" reason="Too Many Requests" />
+          <set-header name="Content-Type" exists-action="override">
+            <value>application/json</value>
+          </set-header>
+          <set-body template="none">{
+  "timestamp": "2026-07-07T12:24:46.230Z",
+  "status": 429,
+  "error": "Too Many Requests",
+  "message": "Request rate limit exceeded",
+  "path": "string",
+  "details": [
+    {
+      "location": "header",
+      "name": "string",
+      "path": "string",
+      "erroneousValue": "string",
+      "message": "string",
+      "expectedPattern": "string",
+      "expectedValueRange": {
+        "minValue": 0,
+        "maxValue": 0
+      },
+      "expectedValueCount": {
+        "minValue": 0,
+        "maxValue": 0
+      },
+      "expectedEnumeration": [
+        "string"
+      ]
+    }
+  ]
+}</set-body>
+        </return-response>
+      </when>
+      <otherwise>
+        <return-response>
+          <set-status code="201" reason="Created" />
+          <set-header name="Content-Type" exists-action="override">
+            <value>application/json</value>
+          </set-header>
+          <set-body template="none">{}</set-body>
+        </return-response>
+      </otherwise>
+    </choose>
+  </inbound>
+  <backend>
+    <base />
+  </backend>
+  <outbound>
+    <base />
+  </outbound>
+  <on-error>
+    <base />
+  </on-error>
+</policies>

--- a/src/srtp/api/test/mock_policy_cancel_epc_v4.xml
+++ b/src/srtp/api/test/mock_policy_cancel_epc_v4.xml
@@ -944,6 +944,428 @@
 }</set-body>
         </return-response>
       </when>
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;999999999999999999014&quot;))">
+        <return-response>
+          <set-status code="201" reason="Created" />
+          <set-header name="Content-Type" exists-action="override">
+            <value>application/json</value>
+          </set-header>
+          <set-body template="none">{
+  "resourceId": "string",
+  "SepaRequestToPayCancellationResponse": {
+    "Document": {
+      "RsltnOfInvstgtn": {
+        "Assgnmt": {
+          "Id": "string",
+          "Assgnr": {
+            "Pty": {
+              "Id": {
+                "OrgId": {
+                  "AnyBIC": "G97MXMNJ",
+                  "LEI": "EDNKSSR7OJFCK5HGE391",
+                  "Othr": {
+                    "Id": "string",
+                    "SchmeNm": {
+                      "Cd": "BANK"
+                    },
+                    "Issr": "string"
+                  }
+                }
+              }
+            }
+          },
+          "Assgne": {
+            "Pty": {
+              "Id": {
+                "OrgId": {
+                  "AnyBIC": "EJ7VIM2P6DZ",
+                  "LEI": "N84IA01SPUZDV8KSO957",
+                  "Othr": {
+                    "Id": "string",
+                    "SchmeNm": {
+                      "Cd": "BANK"
+                    },
+                    "Issr": "string"
+                  }
+                }
+              }
+            }
+          },
+          "CreDtTm": "2026-07-07T12:24:46.224Z"
+        },
+        "Sts": {
+          "Conf": "CNCL"
+        },
+        "CxlDtls": {
+          "OrgnlPmtInfAndSts": [
+            {
+              "OrgnlPmtInfId": "string",
+              "TxInfAndSts": [
+                {
+                  "OrgnlInstrId": "string",
+                  "OrgnlEndToEndId": "string"
+                }
+              ]
+            }
+          ],
+          "TxInfAndSts": [
+            {
+              "CxlStsId": "string",
+              "OrgnlGrpInf": {
+                "OrgnlMsgId": "string",
+                "OrgnlMsgNmId": "string",
+                "OrgnlCreDtTm": "2026-07-07T12:24:46.224Z"
+              },
+              "OrgnlInstrId": "string",
+              "OrgnlEndToEndId": "string",
+              "OrgnlTxId": "string",
+              "TxCxlSts": "ACCR",
+              "CxlStsRsnInf": {
+                "Orgtr": {
+                  "Id": {
+                    "OrgId": {
+                      "AnyBIC": "JYSVKCV4529",
+                      "LEI": "LGDFSQ844N6JZIG1JY44",
+                      "Othr": {
+                        "Id": "string",
+                        "SchmeNm": {
+                          "Cd": "BANK"
+                        },
+                        "Issr": "string"
+                      }
+                    }
+                  }
+                },
+                "AddtlInf": [
+                  "string"
+                ]
+              },
+              "RsltnRltdInf": {
+                "Chrgs": {
+                  "Amt": 0.01,
+                  "Agt": {
+                    "FinInstnId": {
+                      "BICFI": "4B57ZXNU",
+                      "LEI": "B74OLVW7LP0P6A4VPE31",
+                      "Othr": {
+                        "Id": "string",
+                        "SchmeNm": {
+                          "Cd": "stri"
+                        },
+                        "Issr": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              "OrgnlTxRef": {
+                "Amt": {
+                  "InstdAmt": 999999999.99
+                },
+                "ReqdExctnDt": {
+                  "Dt": "string"
+                },
+                "PmtTpInf": {
+                  "SvcLvl": {
+                    "Cd": "SEPA"
+                  },
+                  "LclInstrm": {
+                    "Cd": "string"
+                  }
+                },
+                "RmtInf": {
+                  "Ustrd": "string",
+                  "Strd": {
+                    "RfrdDocAmt": {
+                      "CdtNoteAmt": 999999999.99
+                    },
+                    "CdtrRefInf": {
+                      "Tp": {
+                        "CdOrPrtry": {
+                          "Cd": "SCOR"
+                        },
+                        "Issr": "string"
+                      },
+                      "Ref": "string"
+                    }
+                  }
+                },
+                "DbtrAgt": {
+                  "FinInstnId": {
+                    "BICFI": "22O9XJ9ME5V",
+                    "LEI": "0RP0MY5ZOJSWRKAQPQ30",
+                    "Othr": {
+                      "Id": "string",
+                      "SchmeNm": {
+                        "Cd": "stri"
+                      },
+                      "Issr": "string"
+                    }
+                  }
+                },
+                "CdtrAgt": {
+                  "FinInstnId": {
+                    "BICFI": "MMI1VJUKRS9",
+                    "LEI": "M3OKJHV9NXIYJ45YZL45",
+                    "Othr": {
+                      "Id": "string",
+                      "SchmeNm": {
+                        "Cd": "stri"
+                      },
+                      "Issr": "string"
+                    }
+                  }
+                },
+                "Cdtr": {
+                  "Pty": {
+                    "Nm": "string",
+                    "Id": {
+                      "OrgId": {
+                        "AnyBIC": "9RG4IV5X",
+                        "LEI": "MZGAR0ZD0SJXT4ERHT80",
+                        "Othr": {
+                          "Id": "string",
+                          "SchmeNm": {
+                            "Cd": "BANK"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "CdtrAcct": {
+                  "Id": {
+                    "IBAN": "EQ33IE"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "_links": {
+    "initialSepaRequestToPayUri": {
+      "href": "string",
+      "templated": false
+    }
+  },
+  "invalid-field": "invalid"
+}</set-body>
+        </return-response>
+      </when>
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;999999999999999999015&quot;))">
+        <return-response>
+          <set-status code="201" reason="Created" />
+          <set-header name="Content-Type" exists-action="override">
+            <value>application/json</value>
+          </set-header>
+          <set-body template="none">{
+  "resourceId": "string",
+  "SepaRequestToPayCancellationResponse": {
+    "Document": {
+      "RsltnOfInvstgtn": {
+        "Assgnmt": {
+          "Id": "string",
+          "Assgnr": {
+            "Pty": {
+              "Id": {
+                "OrgId": {
+                  "AnyBIC": "G97MXMNJ",
+                  "LEI": "EDNKSSR7OJFCK5HGE391",
+                  "Othr": {
+                    "Id": "string",
+                    "SchmeNm": {
+                      "Cd": "BANK"
+                    },
+                    "Issr": "string"
+                  }
+                }
+              }
+            }
+          },
+          "Assgne": {
+            "Pty": {
+              "Id": {
+                "OrgId": {
+                  "AnyBIC": "EJ7VIM2P6DZ",
+                  "LEI": "N84IA01SPUZDV8KSO957",
+                  "Othr": {
+                    "Id": "string",
+                    "SchmeNm": {
+                      "Cd": "BANK"
+                    },
+                    "Issr": "string"
+                  }
+                }
+              }
+            }
+          },
+          "CreDtTm": "2026-07-07T12:24:46.224Z"
+        },
+        "Sts": {
+          "Conf": "RJCR"
+        },
+        "CxlDtls": {
+          "OrgnlPmtInfAndSts": [
+            {
+              "OrgnlPmtInfId": "string",
+              "TxInfAndSts": [
+                {
+                  "OrgnlInstrId": "string",
+                  "OrgnlEndToEndId": "string"
+                }
+              ]
+            }
+          ],
+          "TxInfAndSts": [
+            {
+              "CxlStsId": "string",
+              "OrgnlGrpInf": {
+                "OrgnlMsgId": "string",
+                "OrgnlMsgNmId": "string",
+                "OrgnlCreDtTm": "2026-07-07T12:24:46.224Z"
+              },
+              "OrgnlInstrId": "string",
+              "OrgnlEndToEndId": "string",
+              "OrgnlTxId": "string",
+              "TxCxlSts": "ACCR",
+              "CxlStsRsnInf": {
+                "Orgtr": {
+                  "Id": {
+                    "OrgId": {
+                      "AnyBIC": "JYSVKCV4529",
+                      "LEI": "LGDFSQ844N6JZIG1JY44",
+                      "Othr": {
+                        "Id": "string",
+                        "SchmeNm": {
+                          "Cd": "BANK"
+                        },
+                        "Issr": "string"
+                      }
+                    }
+                  }
+                },
+                "AddtlInf": [
+                  "string"
+                ]
+              },
+              "RsltnRltdInf": {
+                "Chrgs": {
+                  "Amt": 0.01,
+                  "Agt": {
+                    "FinInstnId": {
+                      "BICFI": "4B57ZXNU",
+                      "LEI": "B74OLVW7LP0P6A4VPE31",
+                      "Othr": {
+                        "Id": "string",
+                        "SchmeNm": {
+                          "Cd": "stri"
+                        },
+                        "Issr": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              "OrgnlTxRef": {
+                "Amt": {
+                  "InstdAmt": 999999999.99
+                },
+                "ReqdExctnDt": {
+                  "Dt": "string"
+                },
+                "PmtTpInf": {
+                  "SvcLvl": {
+                    "Cd": "SEPA"
+                  },
+                  "LclInstrm": {
+                    "Cd": "string"
+                  }
+                },
+                "RmtInf": {
+                  "Ustrd": "string",
+                  "Strd": {
+                    "RfrdDocAmt": {
+                      "CdtNoteAmt": 999999999.99
+                    },
+                    "CdtrRefInf": {
+                      "Tp": {
+                        "CdOrPrtry": {
+                          "Cd": "SCOR"
+                        },
+                        "Issr": "string"
+                      },
+                      "Ref": "string"
+                    }
+                  }
+                },
+                "DbtrAgt": {
+                  "FinInstnId": {
+                    "BICFI": "22O9XJ9ME5V",
+                    "LEI": "0RP0MY5ZOJSWRKAQPQ30",
+                    "Othr": {
+                      "Id": "string",
+                      "SchmeNm": {
+                        "Cd": "stri"
+                      },
+                      "Issr": "string"
+                    }
+                  }
+                },
+                "CdtrAgt": {
+                  "FinInstnId": {
+                    "BICFI": "MMI1VJUKRS9",
+                    "LEI": "M3OKJHV9NXIYJ45YZL45",
+                    "Othr": {
+                      "Id": "string",
+                      "SchmeNm": {
+                        "Cd": "stri"
+                      },
+                      "Issr": "string"
+                    }
+                  }
+                },
+                "Cdtr": {
+                  "Pty": {
+                    "Nm": "string",
+                    "Id": {
+                      "OrgId": {
+                        "AnyBIC": "9RG4IV5X",
+                        "LEI": "MZGAR0ZD0SJXT4ERHT80",
+                        "Othr": {
+                          "Id": "string",
+                          "SchmeNm": {
+                            "Cd": "BANK"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "CdtrAcct": {
+                  "Id": {
+                    "IBAN": "EQ33IE"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  },
+  "_links": {
+    "initialSepaRequestToPayUri": {
+      "href": "string",
+      "templated": false
+    }
+  },
+  "invalid-field": "invalid"
+}</set-body>
+        </return-response>
+      </when>
       <otherwise>
         <return-response>
           <set-status code="201" reason="Created" />

--- a/src/srtp/api/test/mock_policy_cancel_epc_v4.xml
+++ b/src/srtp/api/test/mock_policy_cancel_epc_v4.xml
@@ -1366,6 +1366,15 @@
 }</set-body>
         </return-response>
       </when>
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;999999999999999016&quot;))">
+        <return-response>
+          <set-status code="201" reason="Created" />
+          <set-header name="Content-Type" exists-action="override">
+            <value>application/json</value>
+          </set-header>
+          <set-body template="none">Test string</set-body>
+        </return-response>
+      </when>
       <otherwise>
         <return-response>
           <set-status code="201" reason="Created" />


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

- Added a new APIM mock policy `src/srtp/api/test/mock_policy_cancel_epc_v4.xml` for the `postRequestToPayCancellationRequest-v4` mock operation, replacing the previous `mock_policy_epc_v4.xml`.
- Updated `src/srtp/99_locals.tf` so `postRequestToPayCancellationRequest-v4` now loads `./api/test/mock_policy_cancel_epc_v4.xml` instead of `./api/test/mock_policy_epc_v4.xml`.
- The new mock policy matches on a distinct "notice number" contained in the request body and returns a specific status code / response body for each test case, covering both success and error scenarios of the EPC cancellation request-to-pay flow.
- Fixed the notice numbers used to trigger the mock cases: they are now 18 digits long (`999999999999999000`-`999999999999999015`) instead of the initial 21-digit values.

Test cases added, in the order they are evaluated (first match wins), together with the notice number that triggers them:

| # | Notice number to use in request body | HTTP status returned | Response body |
|---|----------------------------------------|-----------------------|----------------|
| 1 | `999999999999999000` | 201 Created | Empty JSON object `{}` |
| 2 | `999999999999999001` | 201 Created | Plain string `"Test string"` |
| 3 | `999999999999999002` | 201 Created | Minimal JSON `{"test": "test_value"}` |
| 4 | `999999999999999003` | 201 Created | Full cancellation response, `Sts.Conf = "CNCL"` (cancellation confirmed) |
| 5 | `999999999999999004` | 201 Created | Full cancellation response without the `Sts` block |
| 6 | `999999999999999005` | 201 Created | Full cancellation response, `Sts.Conf = "RJCR"` (cancellation rejected) |
| 7 | `999999999999999006` | 400 Bad Request | Error payload (`error: "Bad Request"`) |
| 8 | `999999999999999007` | 401 Unauthorized | Error payload (`error: "Unauthorized"`) |
| 9 | `999999999999999008` | 404 Not Found | Error payload (`error: "Not Found"`) |
| 10 | `999999999999999009` | 406 Not Acceptable | Error payload (`error: "Not Acceptable"`) |
| 11 | `999999999999999010` | 410 Gone | Error payload (`error: "Gone"`) |
| 12 | `999999999999999011` | 415 Unsupported Media Type | Error payload (`error: "Unsupported Media Type"`) |
| 13 | `999999999999999012` | 422 Unprocessable Entity | Error payload (`error: "Unprocessable Entity"`) |
| 14 | `999999999999999013` | 429 Too Many Requests | Error payload (`error: "Too Many Requests"`) |
| 15 | `999999999999999014` | 201 Created | Same response as case 4 (`Sts.Conf = "CNCL"`), plus an extra unexpected `"invalid-field": "invalid"` property, to test client tolerance to unknown fields |
| 16 | `999999999999999015` | 201 Created | Same response as case 6 (`Sts.Conf = "RJCR"`), plus an extra unexpected `"invalid-field": "invalid"` property, to test client tolerance to unknown fields |
| 17 | `999999999999999016` | 201 Created | Plain string `Test string`, **not** JSON-quoted (same content as case 2, but without the surrounding `"..."`), to test client tolerance to malformed/non-JSON responses |
| — | any other value (no match) | 201 Created | Empty JSON object `{}` (default/fallback case) |

All error payloads (cases 7-14) share the same shape:

```json
{
  "timestamp": "...",
  "status": <matching HTTP status>,
  "error": "<matching reason phrase>",
  "message": "<scenario-specific message>",
  "path": "string",
  "details": [ { ... } ]
}
```

### Motivation and context

The EPC cancellation mock needed a broader and more predictable set of test cases so consumers of the `postRequestToPayCancellationRequest-v4` mock API can exercise both the happy path (with different cancellation outcomes) and the full range of HTTP error responses, plus malformed/unexpected-field responses, by simply sending a specific notice number in the request body.

### Type of changes

- [x] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
