### PR TITLE
feat: [SRTP-1998] add version header validation policy to RTP callback API

### DIFF
--- a/src/srtp/99_locals.tf
+++ b/src/srtp/99_locals.tf
@@ -154,6 +154,9 @@ locals {
         content_format = "openapi"
         content_value  = templatefile("./api/epc/callback.openapi.yaml", {})
       }
+      api_policy = {
+        xml_content = file("./api/epc/callback_policy.xml")
+      }
     }
 
     # RTP Service Provider v1

--- a/src/srtp/api/epc/callback_policy.xml
+++ b/src/srtp/api/epc/callback_policy.xml
@@ -1,0 +1,25 @@
+<policies>
+  <inbound>
+    <base />
+    <choose>
+      <when condition="@(context.Request.Headers.ContainsKey(&quot;Version&quot;))">
+        <return-response>
+          <set-status code="400" reason="Bad Request" />
+          <set-header name="Content-Type" exists-action="override">
+            <value>application/json</value>
+          </set-header>
+          <set-body>{"title":"Invalid request","detail":"Header 'Version' must not be sent for callback APIs."}</set-body>
+        </return-response>
+      </when>
+    </choose>
+  </inbound>
+  <backend>
+    <base />
+  </backend>
+  <outbound>
+    <base />
+  </outbound>
+  <on-error>
+    <base />
+  </on-error>
+</policies>

--- a/src/srtp/api/epc/callback_policy.xml
+++ b/src/srtp/api/epc/callback_policy.xml
@@ -8,7 +8,7 @@
           <set-header name="Content-Type" exists-action="override">
             <value>application/json</value>
           </set-header>
-          <set-body>{"title":"Invalid request","detail":"Header 'Version' must not be sent for callback APIs."}</set-body>
+          <set-body>{"status":400,"error":"Bad Request","message":"Header 'Version' must not be sent for callback APIs."}</set-body>
         </return-response>
       </when>
     </choose>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

- Added a new inbound policy (`src/srtp/api/epc/callback_policy.xml`) to the RTP EPC `callback` API that rejects any request containing a `Version` header with a `400 Bad Request` response (`{"status":400,"error":"Bad Request","message":"Header 'Version' must not be sent for callback APIs."}`).
- Wired the new policy file into the `callback` API definition in `src/srtp/99_locals.tf` via the `api_policy.xml_content` attribute, so it is applied through the existing `api_policy` mechanism.

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

The RTP callback API must not receive a `Version` header. This policy enforces that constraint at the API Management gateway level, returning an explicit `400` error instead of allowing the request to reach the backend.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [x] DEV
- [x] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

None.

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->