### PR TITLE
feat: [SRTP-2120] add error handling for specific request body in mock policy

### DIFF
--- a/src/srtp/api/test/mock_policy_epc.xml
+++ b/src/srtp/api/test/mock_policy_epc.xml
@@ -388,6 +388,15 @@
             }</set-body>
         </return-response>
       </when>
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;XKEWKK98L22M788S&quot;))">
+        <return-response>
+          <set-status code="400" reason="Bad Request" />
+          <set-header name="Content-Type" exists-action="override">
+            <value>application/json</value>
+          </set-header>
+          <set-body template="none">{"status":500,"error":"RTP_05.CHK.A0007","message":"Unexpected status code received by rtp system"}</set-body>
+        </return-response>
+      </when>
       <otherwise>
         <return-response>
           <set-status code="201" reason="Created" />


### PR DESCRIPTION
### List of changes

- Removed the successful mock scenarios from `src/srtp/api/test/mock_policy_epc.xml` so the EPC mock now keeps only the error/negative branches.
- The remaining mock branches continue to return the failure cases used to exercise the error handling flow.

### Motivation and context

The SRTP EPC mock was carrying a mix of successful and negative fixtures. This change narrows the policy to the cases that are actually needed for error-path testing, reducing ambiguity and keeping the mock behavior aligned with the intended test coverage.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [x] DEV
- [x] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

This update affects only the mock policy used for testing.

---

### If PR is partially applied, why? (reserved to mantainers)

N/A
