### PR TITLE
fix: [SRTP-2146] add error response for specific request body in mock policy

### DIFF
--- a/src/srtp/api/test/mock_policy_epc_v4.xml
+++ b/src/srtp/api/test/mock_policy_epc_v4.xml
@@ -394,6 +394,15 @@
             }</set-body>
         </return-response>
       </when>
+      <when condition="@(context.Request.Body.As<string>(preserveContent: true).Contains(&quot;QGJVWV87B01C628F&quot;))">
+        <return-response>
+          <set-status code="400" reason="Bad Request" />
+          <set-header name="Content-Type" exists-action="override">
+            <value>application/json</value>
+          </set-header>
+          <set-body template="none">{"status":500,"error":"RTP_05.CHK.A0007","message":"Unexpected status code received by rtp system"}</set-body>
+        </return-response>
+      </when>
       <otherwise>
         <return-response>
           <set-status code="201" reason="Created" />


### PR DESCRIPTION
### List of changes

- Added a new negative mock v2 case for CF `XKEWKK98L22M788S` in `src/srtp/api/test/mock_policy_epc_v4.xml`, returning `400 Bad Request` with error code `RTP_05.CHK.A0007`.

### Motivation and context

This change introduces only the additional negative branch required for error-path testing of the mock v2 flow.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [x] DEV
- [x] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

This update affects only the mock policy used for testing.

---

### If PR is partially applied, why? (reserved to mantainers)

N/A
